### PR TITLE
Fix compilation by reordering references

### DIFF
--- a/draft-barnes-mls-protocol.md
+++ b/draft-barnes-mls-protocol.md
@@ -39,7 +39,6 @@ author:
 
 
 normative:
-  IEEE1363: DOI.10.1109/IEEESTD.2009.4773330
   X962:
        title: "Public Key Cryptography For The Financial Services Industry: The Elliptic Curve Digital Signature Algorithm (ECDSA)"
        date: 1998
@@ -47,6 +46,7 @@ normative:
          org: ANSI
        seriesinfo:
          ANSI: X9.62
+  IEEE1363: DOI.10.1109/IEEESTD.2009.4773330
 
 
 informative:


### PR DESCRIPTION
Because xml2rfc is crazy, if the first reference in a reference list
does not include an author then xml2rfc will _actually crash_ with an
UnboundLocalError (http://xml2rfc.xml.resource.narkive.com/DzQ2CS0L/243-version-2-cli-problem-in-html-rendering-of-minimal-references):

```
xml2rfc -q draft-barnes-mls-protocol.xml -o draft-barnes-mls-protocol.htmltmp --html
Traceback (most recent call last):
  File "/usr/local/bin/xml2rfc", line 225, in <module>
    main()
  File "/usr/local/bin/xml2rfc", line 192, in main
    htmlwriter.write(filename)
  File "/Users/katrielalex/Library/Python/2.7/lib/python/site-packages/xml2rfc/writers/base.py", line 1218, in write
    self._build_document()
  File "/Users/katrielalex/Library/Python/2.7/lib/python/site-packages/xml2rfc/writers/base.py", line 1164, in _build_document
    self.write_reference_list(reference_list)
  File "/Users/katrielalex/Library/Python/2.7/lib/python/site-packages/xml2rfc/writers/html.py", line 569, in write_reference_list
    a.tail = ', '
UnboundLocalError: local variable 'a' referenced before assignment
```

Yes, this is crazy. In lieu of actually fixing the problem, here we
just reorder the references so it compiles.