### PR TITLE
Rename from draft-barnes to draft-ietf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ pulls.json
 report.xml
 lib
 draft-barnes-mls-protocol.xml
+lib
+draft-ietf-mls-protocol.xml

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,4 @@ issues.json
 pulls.json
 report.xml
 lib
-draft-barnes-mls-protocol.xml
-lib
 draft-ietf-mls-protocol.xml

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
 # License
 
 See the
-[guidelines for contributions](https://github.com/ekr/mls-protocol/blob/master/CONTRIBUTING.md).
+[guidelines for contributions](https://github.com/mlswg/mls-protocol/blob/master/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This is the working area for the individual Internet-Draft, "".
 
-* [Editor's Copy](https://ekr.github.io/mls-protocol/#go.draft-barnes-mls-protocol.html)
-* [Working Group Draft](https://tools.ietf.org/html/draft-barnes-mls-protocol)
-* [Compare Editor's Copy to Working Group Draft](https://ekr.github.io/mls-protocol/#go.draft-barnes-mls-protocol.diff)
+* [Editor's Copy](https://mlswg.github.io/mls-protocol/#go.draft-ietf-mls-protocol.html)
+* [Working Group Draft](https://tools.ietf.org/html/draft-ietf-mls-protocol)
+* [Compare Editor's Copy to Working Group Draft](https://mlswg.github.io/mls-protocol/#go.draft-ietf-mls-protocol.diff)
 
 ## Building the Draft
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 
 
-This is the working area for the individual Internet-Draft, "".
+This is the working area for the IETF MLS Working Group Internet-Draft, "".
 
 * [Editor's Copy](https://mlswg.github.io/mls-protocol/#go.draft-ietf-mls-protocol.html)
 * [Working Group Draft](https://tools.ietf.org/html/draft-ietf-mls-protocol)
@@ -21,4 +21,4 @@ This requires that you have the necessary software installed.  See
 ## Contributing
 
 See the
-[guidelines for contributions](https://github.com/ekr/mls-protocol/blob/master/CONTRIBUTING.md).
+[guidelines for contributions](https://github.com/mlswg/mls-protocol/blob/master/CONTRIBUTING.md).

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -97,7 +97,7 @@ for building production systems.
 
 RFC EDITOR: PLEASE REMOVE THE FOLLOWING PARAGRAPH The source for
 this draft is maintained in GitHub. Suggested changes should be
-submitted as pull requests at https://github.com/ekr/mls-protocol.
+submitted as pull requests at https://github.com/mlswg/mls-protocol.
 Instructions are on that page as well. Editorial changes can be
 managed in GitHub, but any substantive change should be discussed on
 the MLS mailing list.

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1,7 +1,7 @@
 ---
 title: The Messaging Layer Security (MLS) Protocol
 abbrev: MLS
-docname: draft-barnes-mls-protocol-latest
+docname: draft-ietf-mls-protocol-latest
 category: info
 
 ipr: trust200902


### PR DESCRIPTION
Note: If you have an existing clone, you will need to delete `.targets.mk` at the root level of the clone in order for `make submit` to work. (`make` will still work fine)