### PR TITLE
Remove UserAdd

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -944,7 +944,7 @@ Update Secret -> HKDF-Extract = Epoch Secret
 
 In order to facilitate asynchronous addition of participants to a
 group, it is possible to pre-publish initialization keys that
-provide some public information about a user or group.  UserInitKey
+provide some public information about a user.  UserInitKey
 messages provide information about a potential group member, that a group member can use to
 add this user to a group asynchronously.
 
@@ -1098,7 +1098,9 @@ A group member generates this message using the following steps:
 
 The public key of the ephemeral key pair is placed in the
 `ephemeral` field of the Add message.  The computed direct path
-is placed in the `add_path` field.
+is placed in the `add_path` field.  The frontiers of the identity
+and ratchet trees before the addition of the new member are placed
+in the `identity_frontier` and `ratchet_frontier`.
 
 The new participant processes the message and the private key corresponding
 to the UserInitKey to initialize his state as follows:

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -175,7 +175,7 @@ Identity Key:
 Terminology specific to tree computations is described in
 {{binary-trees}}.
 
-We use the TLS presentation language {{RFC8446}} to
+We use the TLS presentation language {{!RFC8446}} to
 describe the structure of protocol messages.
 
 
@@ -245,11 +245,11 @@ A              B              C          Directory       Channel
 
 When a participant A wants to establish a group with B and C, it
 first downloads InitKeys for B and C.  It then initializes a group state
-containing only itself and uses the InitKeys to compute GroupAdd messages
+containing only itself and uses the InitKeys to compute Add messages
 to add B and C, in a sequence chosen by A.
 These messages are broadcasted to the Group, and processed in sequence
 by B and C.  Messages received before a participant has joined the
-group are ignored.  Only after A has received its GroupAdd messages
+group are ignored.  Only after A has received its Add messages
 back from the server does it update its state to reflect their addition.
 
 
@@ -260,18 +260,18 @@ A              B              C          Directory            Channel
 |         UserInitKeyB, UserInitKeyC         |                   |
 |<-------------------------------------------|                   |
 |              |              |              |                   |
-|              |              |              | GroupAdd(A->AB)   |
+|              |              |              | Add(A->AB)        |
 |--------------------------------------------------------------->|
 |              |              |              |                   |
-|              |              |              | GroupAdd(AB->ABC) |
+|              |              |              | Add(AB->ABC)      |
 |--------------------------------------------------------------->|
 |              |              |              |                   |
-|              |              |              | GroupAdd(A->AB)   |
+|              |              |              | Add(A->AB)        |
 |<---------------------------------------------------------------|
 |state.add(B)  |<------------------------------------------------|
 |              |state.init()  |x---------------------------------|
 |              |              |              |                   |
-|              |              |              | GroupAdd(AB->ABC) |
+|              |              |              | Add(AB->ABC)      |
 |<---------------------------------------------------------------|
 |state.add(C)  |<------------------------------------------------|
 |              |state.add(C)  |<---------------------------------|
@@ -281,44 +281,8 @@ A              B              C          Directory            Channel
 
 Subsequent additions of group members proceed in the same way.  Any
 member of the group can download an InitKey for a new participant
-and broadcast a GroupAdd which the current group can use to update
+and broadcast an Add which the current group can use to update
 their state and the new participant can use to initialize its state.
-
-It is sometimes necessary for a new participant to join without
-an explicit invitation from a current member.  For example, if a
-user that is authorized to be in the group logs in on a new device,
-that device will need to join the group as a new participant, but
-will not have been invited.
-
-In these "user-initiated join" cases, the "InitKey + Add message"
-flow is reversed.  We assume that at some previous point, a group
-member has published a GroupInitKey reflecting the current state of
-the group (A, B, C).  The new participant Z downloads that
-GroupInitKey from the directory, generates a UserAdd message, and
-broadcasts it to the group.  Once current members process this
-message, they will have a shared state that also includes Z.
-
-~~~~~
-                                                          Group
-A              B     ...      Z          Directory       Channel
-| GroupInitKey |              |              |              |
-|------------------------------------------->|              |
-|              |              |              |              |
-~              ~              ~              ~              ~
-|              |              |              |              |
-|              |              | GroupInitKey |              |
-|              |              |<-------------|              |
-|              |              |              |              |
-|              |              | UserAdd(.->D)|              |
-|              |              |---------------------------->|
-|              |              |              |              |
-|              |              |              | UserAdd(.->D)|
-|<----------------------------------------------------------|
-|state.add(D)  |<-------------------------------------------|
-|              |state.add(D)  |<----------------------------|
-|              |              |state.init()  |              |
-|              |              |              |              |
-~~~~~
 
 To enforce forward secrecy and post-compromise security of messages,
 each participant periodically updates its leaf secret which represents
@@ -945,7 +909,7 @@ following information to derive new epoch secrets:
 The derivation of the update secret depends on the change being
 made, as described below.
 
-For UserAdd or GroupAdd, the new user does not know the prior epoch init secret.
+For Add, the new user does not know the prior epoch init secret.
 Instead, entropy from the prior epoch is added via the update secret,
 and an all-zero vector with the same length as a hash output is used
 in the place of the init secret.
@@ -1093,10 +1057,9 @@ list of participant identity keys.
 enum {
     none(0),
     init(1),
-    user_add(2),
-    group_add(3),
-    update(4),
-    delete(5),
+    add(2),
+    update(3),
+    delete(4),
     (255)
 } HandshakeType;
 
@@ -1106,8 +1069,7 @@ struct {
     select (Handshake.msg_type) {
         case none:      struct{};
         case init:      Init;
-        case user_add:  UserAdd;
-        case group_add: GroupAdd;
+        case add:       Add;
         case update:    Update;
         case delete:    Delete;
     };
@@ -1130,7 +1092,7 @@ keys used to sign messages.  This integration will enable meaningful
 authentication (of identities, rather than keys), and will need to
 be done in such a way as to prevent unknown key share attacks. ]]
 
-[[ OPEN ISSUE: The GroupAdd and Delete operations create a "double-join"
+[[ OPEN ISSUE: The Add and Delete operations create a "double-join"
 situation, where a participants leaf key is also known to another
 participant.  When a participant A is double-joined to another B,
 deleting A will not remove them from the conversation, since they
@@ -1155,16 +1117,16 @@ including only itself, then adding the initial participants.  This
 has computation and communication complexity O(N log N) instead of
 the O(N) complexity of direct initialization. ]]
 
-## GroupAdd
+## Add
 
-A GroupAdd message is sent by a group member to add a new participant
+An Add message is sent by a group member to add a new participant
 to the group.
 
 ~~~~~
 struct {
     PublicKey ephemeral;
     DirectPath add_path<1..2^16-1>;
-} GroupAdd;
+} Add;
 ~~~~~
 
 A group member generates this message using the following steps:
@@ -1178,7 +1140,7 @@ A group member generates this message using the following steps:
   direct path between the new leaf and the new root
 
 The public key of the ephemeral key pair is placed in the
-`ephemeral` field of the GroupAdd message.  The computed direct path
+`ephemeral` field of the Add message.  The computed direct path
 is placed in the `add_path` field.
 
 The new participant processes the message and the private key corresponding
@@ -1189,7 +1151,7 @@ to the UserInitKey to initialize his state as follows:
 * Use the frontiers in the GroupInitKey of the Handshake message to
   add its keys to the trees
 
-An existing participant receiving a GroupAdd message first verifies
+An existing participant receiving a Add message first verifies
 the signature on the message, then verifies its identity proof against
 the identity tree held by the participant. The participant then updates
 its state as follows:
@@ -1198,41 +1160,6 @@ its state as follows:
   key in the UserInitKey with the prior epoch add key pair
 * Update the group's identity tree and ratchet tree with the new
   participant's information
-
-The update secret resulting from this change is the output of a DH
-computation between the private key for the root of the ratchet tree
-and the add public key from the previous epoch.
-
-## UserAdd
-
-A UserAdd message is sent by a new group participant to add
-themself to the group, based on having already had access to a
-GroupInitKey for the group.
-
-~~~~~
-struct {
-    DirectPath add_path;
-} UserAdd;
-~~~~~
-
-A new participant generates this message using the following steps:
-
-* Fetch a GroupInitKey for the group
-* Use the frontiers in the GroupInitKey to add its keys to the trees
-* Compute the direct path from the new participant's leaf in the new
-  ratchet tree (the add\_path).
-
-An existing participant receiving a UserAdd first verifies the
-signature on the message, then verifies its identity inclusion proof
-against the updated identity tree expressed in the GroupInitKey of
-the Handshake message (since the signer is not included in the prior
-group state held by the existing participant).  The participant then
-updates its state as follows:
-
-* Update trees with the descriptions in the new GroupInitKey
-* Update the local ratchet tree with the information in the UserAdd
-  message, replacing any common nodes with the values in the add
-  path
 
 The update secret resulting from this change is the output of a DH
 computation between the private key for the root of the ratchet tree


### PR DESCRIPTION
I would like to remove the UserAdd functionality that's in the current document, and the GroupInitKey construct that supports it.  We will need to support a flow where a device can join without an explicit invite.  But that mechanism will also have to be limited,  since it leaks information out of the group.  It will be cleaner to get a GroupAdd-only system working first, then figure out how to add this back in.