### PR TITLE
Authn v2

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -140,23 +140,29 @@ RFC EDITOR PLEASE DELETE THIS SECTION.
 
 draft-01
 
-- Initial description of the Message Protection mechanism. (*)
+- Initial description of the Message Protection mechanism. (\*)
 
 - Initial specification proposal for the Application Key Schedule
-  using the per-participant chaining of the Application Secret design. (*)
+  using the per-participant chaining of the Application Secret design. (\*)
 
 - Initial specification proposal for an encryption mechanism to protect
-  Application Messages using an AEAD scheme. (*)
+  Application Messages using an AEAD scheme. (\*)
 
 - Initial specification proposal for an authentication mechanism
-  of Application Messages using signatures. (*)
+  of Application Messages using signatures. (\*)
 
 - Initial specification proposal for a padding mechanism to improving
-  protection of Application Messages against traffic analysis. (*)
+  protection of Application Messages against traffic analysis. (\*)
 
 - Inversion of the Group Init Add and Application Secret derivations
   in the Handshake Key Schedule to be ease chaining in case we switch
-  design. (*)
+  design. (\*)
+
+- Removal of the UserAdd construct and split of GroupAdd into Add
+  and Welcome messages (\*)
+
+- Initial proposal for authenticating Handshake messages by signing
+  over group state and including group state in the key schedule (\*)
 
 draft-00
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -659,6 +659,46 @@ tree management to behave as for a balanced tree for programming simplicity.
 
 # Group State
 
+Each participant in the group maintains a representation of the
+state of the group:
+
+~~~~~
+struct GroupState {
+  opaque group_id<...>;
+  uint32 size;
+  uint32 epoch;
+  Credential roster<...>;
+  PublicKey tree<...>;
+  opaque transcript_hash<...>;
+}
+~~~~~
+
+The fields in this state have the following semantics:
+
+* The `group_id` field is an application-defined identifier for the
+  group.
+* The `size` field represents the total number of key-exchange slots
+  in the group, whether or not these slots are currently occupied.
+* The `epoch` field represents the current version of the group key.
+* The `roster` field contains credentials for the occupied slots in
+  the tree, including the identity and public key for the holder of
+  the slot.  The length of the `roster` vector MUST be equal to the
+  value of the `size` field; the n-th entry in the vector represents
+  the identity for the n-th slot, if any.
+* The `tree` field contains the public keys corresponding to the
+  nodes of the ratchet tree for this group.  The length of this
+  vector MUST be `2*size + 1`.
+
+When a new member is added to the group, an existing member of the
+group provides the new member with a Welcome message.  The Welcome
+message provides the information the new member needs to initialize
+its GroupState.
+
+Other group operations will have different affects on the group
+state
+
+======
+
 The state of an MLS group at a given time comprises:
 
 * A group identifier (GID)


### PR DESCRIPTION
This PR reflects a concrete scheme on top of #58 that implements the authentication framework discussed on the list recently.  There are a few major changes:

* Defines a `GroupState` structure that is incorporated into the key schedule and signatures
* Adds a `Welcome` message that provisions a new member with roster and tree information
* Removes the Merkle tree over group identities (and related definitions), since all participants now keep the full roster