### PR TITLE
Remove ART

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -603,7 +603,7 @@ opaque SignaturePublicKey<1..2^16-1>;
 
 ### Curve25519, SHA-256, and AES-128-GCM
 
-This ciphersuite uses the following primities:
+This ciphersuite uses the following primitives:
 
 * Hash function: SHA-256
 * Diffie-Hellman group: Curve25519 {{!RFC7748}}
@@ -627,7 +627,7 @@ Encryption keys are derived from shared secrets by taking the first
 
 ### P-256, SHA-256, and AES-128-GCM
 
-This ciphersuite uses the following primities:
+This ciphersuite uses the following primitives:
 
 * Hash function: P-256
 * Diffie-Hellman group: secp256r1 (NIST P-256)

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -762,16 +762,17 @@ struct {
 } ECIESCiphertext;
 
 struct {
-  DHPublicKey nodes<0..2^16-1>;
-  ECIESCiphertext node\_secrets<0..2^16-1>;
+    DHPublicKey public_key;
+    ECIESCiphertext node_secrets<0..2^16-1>;
+} RatchetNode
+
+struct {
+    RatchetNode nodes<0..2^16-1>;
 } DirectPath;
 ~~~~~
 
-The length of the `node\_secrets` vector MUST
-be exactly one less than the length of the `nodes` vector, since the
-secret value for the leaf node is not encrypted.  For `i > 0`,
-`node_secrets[i-1]` has the encrypted node secret corresponding to
-the public key in `nodes[i]`.
+The length of the `node\_secrets` vector MUST be zero for the first
+node in the path and one for all other nodes in the path.
 
 The ECIESCiphertext values encoding the
 encrypted secret values are computed as follows:


### PR DESCRIPTION
There was agreement at the MLS interim of September 2018 to focus further development on TreeKEM, not ART.  This PR implements that change.