### PR TITLE
Remove double-join with the "partial tree" approach

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -746,10 +746,18 @@ state of the group:
 
 ~~~~~
 struct {
+  uint8 present;
+  switch (present) {
+    case 0: struct{};
+    case 1: T value;
+  }
+} optional<T>;
+
+struct {
   opaque group_id<0..255>;
   uint32 epoch;
-  Credential roster<1..2^32-1>;
-  PublicKey tree<1..2^32-1>;
+  optional<Credential> roster<1..2^32-1>;
+  optional<PublicKey> tree<1..2^32-1>;
   opaque transcript_hash<0..255>;
 } GroupState;
 ~~~~~
@@ -1177,17 +1185,16 @@ the signature on the message, then verifies its identity proof
 against the identity tree held by the participant.  The participant
 then updates its state as follows:
 
-* Update the roster by replacing the credential in the removed slot
-  with the credential from the sender's slot (i.e., the sender of
-  the Remove takes over the removed slot)
+* Update the roster by setting the credential in the removed slot to
+  the null optional value
 * Update the ratchet tree by replacing nodes in the direct
   path from the removed leaf using the information in the Remove message
 * Update the ratchet tree by setting to blank all nodes in the
   direct path from the removed leaf to the root
 
 The update secret resulting from this change is the secret for the
-root node of the ratchet tree after both updates.
-
+root node of the ratchet tree after the second step (after the third
+step, the root is blank).
 
 # Sequencing of State Changes {#sequencing}
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1078,9 +1078,10 @@ Note that the `init_secret` in the Welcome message is the
 `init_secret` at the output of the key schedule diagram in
 {{key-schedule}}.  That is, if the `epoch` value in the Welcome
 message is `n`, then the `init_secret` value is `init_secret_[n]`.
-This allows the new member to compute the epoch secret for the next
-epoch (in which it is added), without revealing the secrets for the
-previous epoch.
+The new member can combine this init secret with the update secret
+transmitted in the corresponding Add message to get the epoch secret
+for the epoch in which it is added.  No secrets from prior epochs
+are revealed to the new member.
 
 Since the new member is expected to process the Add message for
 itself, the Welcome message should reflect the state of the group

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -555,8 +555,8 @@ A   _   C   D
 In this tree, we can see all three of the above rules in play:
 
 * The resolution of node 5 is the list [CD]
-* The resolution of node 2 is []
-* The resolution of node 3 is [A, CD]
+* The resolution of node 2 is the empty list []
+* The resolution of node 3 is the list [A, CD]
 
 ## Ratchet Tree Updates
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -568,12 +568,18 @@ direct path from a leaf to the root. Other participants in the group
 can use these nodes to update their view of the tree, aligning their
 copy of the tree to the sender's.
 
-To perform an update, the sender transmits a node by sending the
-public key for the node and one or more encrypted copies of the
-secret value for the node.  The secret value in a node is encrypted
-for the subtree corresponding to the node's non-updated child, by
-encrypting it using the public key of each node in the resolution
-of the non-updated child.
+To perform an update for a leaf, the sender transmits the following
+information for each node in the direct path from leaf leaf to the
+root:
+
+* The public key for the node
+* Zero or more encrypted copies of the node's secret value
+
+The secret value is encrypted for the subtree corresponding to the
+node's non-updated child, i.e., the child not on the direct path.
+There is one encrypted secret for each public key in the resolution
+of the non-updated child.  In particular, for the leaf node, there
+are no encrypted secrets, since a leaf node has no children.
 
 The recipient of an update processes it with the following steps:
 
@@ -900,7 +906,6 @@ update_secret -> HKDF-Extract = epoch_secret
                init_secret_[n]
 ~~~~~
 
-
 # Initialization Keys
 
 In order to facilitate asynchronous addition of participants to a
@@ -1054,6 +1059,14 @@ struct {
   opaque init_secret<0..255>;
 } Welcome;
 ~~~~~
+
+Note that the `init_secret` in the Welcome message is the
+`init_secret` at the output of the key schedule diagram in
+{{key-schedule}}.  That is, if the `epoch` value in the Welcome
+message is `n`, then the `init_secret` value is `init_secret_[n]`.
+This allows the new member to compute the epoch secret for the next
+epoch (in which it is added), without revealing the secrets for the
+previous epoch.
 
 Since the new member is expected to process the Add message for
 itself, the Welcome message should reflect the state of the group

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -918,7 +918,7 @@ times, potentially once. (see {{init-key-reuse}}).
 
 The init\_keys array MUST have the same length as the cipher\_suites
 array, and each entry in the init\_keys array MUST be a public key
-for the DH group or KEM defined by the corresponding entry in the
+for the DH group defined by the corresponding entry in the
 cipher\_suites array.
 
 The whole structure is signed using the client's identity key.  A
@@ -935,7 +935,6 @@ struct {
     opaque signature<0..2^16-1>;
 } UserInitKey;
 ~~~~~
-
 
 # Handshake Messages
 
@@ -1109,6 +1108,11 @@ the signature on the message,  then updates its state as follows:
 * Append an entry to the roster containing the credential in the
   included UserInitKey
 * Update the ratchet tree with the included direct path
+* Update the ratchet tree by setting to blank all nodes in the
+  direct path of the new node
+* Update the ratchet tree by setting the leaf node for the new
+  member to be the public key in the UserInitKey corresponding to
+  the ciphersuite in use
 
 The update secret resulting from this change is the secret for the
 root node of the ratchet tree.
@@ -1166,8 +1170,10 @@ then updates its state as follows:
 * Update the roster by replacing the credential in the removed slot
   with the credential from the sender's slot (i.e., the sender of
   the Remove takes over the removed slot)
-* Update the cached ratchet tree by replacing nodes in the direct
+* Update the ratchet tree by replacing nodes in the direct
   path from the removed leaf using the information in the Remove message
+* Update the ratchet tree by setting to blank all nodes in the
+  direct path from the removed leaf to the root
 
 The update secret resulting from this change is the secret for the
 root node of the ratchet tree after both updates.


### PR DESCRIPTION
This PR updates the procedures for Add and Remove to remove double-joins.  The cost is a potential increase in the size of GroupOperation messages in the case of incomplete trees.

Depends on #66 