### PR TITLE
Add ciphersuites and signature schemes

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -640,9 +640,29 @@ Public keys used in the protocol are opaque values
 in a format defined by the ciphersuite, using the following types:
 
 ~~~~~
-uint16 CipherSuite;
 opaque DHPublicKey<1..2^16-1>;
 opaque SignaturePublicKey<1..2^16-1>;
+~~~~~
+
+Cryptographic algorithms are indicated using the following types:
+
+~~~~~
+enum {
+    /* ECDSA algorithms */
+    ecdsa_secp256r1_sha256(0x0403),
+    ecdsa_secp521r1_sha512(0x0603),
+
+    /* EdDSA algorithms */
+    ed25519(0x0807),
+    ed448(0x0808),
+    (0xFFFF)
+} SignatureScheme;
+
+enum {
+    P256_SHA256_AES128GCM(0x0000),
+    X25519_SHA256_AES128GCM(0x0001),
+    (0xFFFF)
+} CipherSuite;
 ~~~~~
 
 ### Curve25519, SHA-256, and AES-128-GCM

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -648,13 +648,8 @@ Cryptographic algorithms are indicated using the following types:
 
 ~~~~~
 enum {
-    /* ECDSA algorithms */
     ecdsa_secp256r1_sha256(0x0403),
-    ecdsa_secp521r1_sha512(0x0603),
-
-    /* EdDSA algorithms */
     ed25519(0x0807),
-    ed448(0x0808),
     (0xFFFF)
 } SignatureScheme;
 


### PR DESCRIPTION
Need some actual values here for interop.  Signature scheme values are a subset of those in RFC 8446.

@raphaelrobert - Do you think we should go ahead and define the higher-security-level ciphersuites as well as signature algorithms?