### PR TITLE
Bugfixes

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -729,8 +729,12 @@ Encryption keys are derived from shared secrets by taking the first
 A member of a group authenticates the identities of other
 participants by means of credentials issued by some authentication
 system, e.g., a PKI.  Each type of credential MUST express the
-holder's identity as well as the public key of a signature key pair
-that the holder of the credential will use to sign MLS messages.
+following data:
+
+* The public key of a signature key pair
+* The identity of the holder of the private key
+* The signature scheme that the holder will use to sign MLS messages
+
 Credentials MAY also include information that allows a relying party
 to verify the identity / signing key binding.
 
@@ -743,6 +747,7 @@ enum {
 
 struct {
     opaque identity<0..2^16-1>;
+    SignatureScheme algorithm;
     SignaturePublicKey public_key;
 } BasicCredential;
 
@@ -971,8 +976,7 @@ comprises all of the fields except for the signature field.
 struct {
     CipherSuite cipher_suites<0..255>;
     DHPublicKey init_keys<1..2^16-1>;
-    SignatureScheme algorithm;
-    SignaturePublicKey identity_key;
+    Credential credential;
     opaque signature<0..2^16-1>;
 } UserInitKey;
 ~~~~~
@@ -1022,7 +1026,6 @@ struct {
     GroupOperation operation;
 
     uint32 signer_index;
-    SignatureScheme algorithm;
     opaque signature<1..2^16-1>;
     opaque confirmation[Hash.length];
 } Handshake;

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1110,9 +1110,9 @@ current state using the Add message:
 struct {
   opaque group_id<0..255>;
   uint32 epoch;
-  Credential roster<1..2^32-1>;
-  PublicKey tree<1..2^32-1>;
-  GroupOperation transcript<0..2^32-1>;
+  optional<Credential> roster<1..2^32-1>;
+  optional<PublicKey> tree<1..2^32-1>;
+  opaque transcript_hash<0..255>;
   opaque init_secret<0..255>;
 } Welcome;
 ~~~~~

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1027,7 +1027,7 @@ struct {
 
     uint32 signer_index;
     opaque signature<1..2^16-1>;
-    opaque confirmation[Hash.length];
+    opaque confirmation<1..2^8-1>;
 } Handshake;
 ~~~~~
 


### PR DESCRIPTION
This PR fixes several small issues I encountered while bringing my implementation more up to date. 

* When I changed `GroupState` to allow blanks in the tree, I failed to update `Welcome` accordingly
* Credentials should dictate what signature scheme they will be used with, and once that's the case, we no longer need to indicate what algorithm is in use in cases where the signer's credential is known
* `UserInitKeys` should come with a credential, not just a public key
* The confirmation value is easier to parse as an opaque vector value than as an array whose size depends on the ciphersuite in use