### PR TITLE
Garbage collection

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1269,6 +1269,8 @@ then updates its state as follows:
   the null optional value
 * Update the ratchet tree by replacing nodes in the direct
   path from the removed leaf using the information in the Remove message
+* Reduce the size of the roster and the tree until the rightmost
+  element roster element and leaf node are non-null
 * Update the ratchet tree by setting to blank all nodes in the
   direct path from the removed leaf to the root
 


### PR DESCRIPTION
Right now, we blank out leaf nodes when we remove their holders, but we never reduce the size of hte tree or repopulate interior blanks with new members.  This PR adds those functions:

* Reduce the size of the tree and the roster when you remove from the right edge
* Add an `index` field to the `Add` message, to enable new members to be added to blank slots in the tree, not just at the right edge.

In addition to performing "garbage collection", this change should make it easier to do a state resync -- just remove the desync'ed endpoint and add them back in the same spot.

Fixes #86 