### PR TITLE
Update changelong with entries for -03

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -136,6 +136,16 @@ shared keys with costs that scale as the log of the group size.
 
 RFC EDITOR PLEASE DELETE THIS SECTION.
 
+draft-03
+
+- Added ciphersuites and signature schemes (\*)
+
+- Re-ordered fields in UserInitKey to make parsing easier (\*)
+
+- Fixed inconsistencies between Welcome and GroupState (\*)
+
+- Added encryption of the Welcome message (\*)
+
 draft-02
 
 - Removed ART (\*)


### PR DESCRIPTION
I forgot to update the changelog before I published -03.  We should add that to the review criteria.  This will at least fix it for -04.