### PR TITLE
Key Schedule uses the transcript_hash instead of the raw group_state

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1472,8 +1472,8 @@ to be used for its own sending chain:
            application_secret_[sender]_[0]
 ~~~
 
-Note that [sender] represent the uint32 bytes for the big-endian encoding
-the index of the participant in the ratchet tree.
+Note that [sender] represent the big-endian encoding of the uint32 word
+used to store the index of the participant in the ratchet tree.
 
 Updating the Application secret and deriving the associated AEAD key and nonce can
 be summarized as the following Application key schedule where

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -921,7 +921,7 @@ Where HkdfLabel is specified as:
 
 struct {
     uint16 length = Length;
-    opaque label<7..255> = "mls10 " + Label;
+    opaque label<6..255> = "mls10 " + Label;
     opaque context<0..255> = Context;
 } HkdfLabel;
 


### PR DESCRIPTION
This is an attempt to solve #90 and #107.