### PR TITLE
Rephrased sentence in Add section.

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1161,9 +1161,7 @@ are revealed to the new member.
 
 Since the new member is expected to process the Add message for
 itself, the Welcome message should reflect the state of the group
-before the new user is added.  The sender of the Welcome message can
-simply copy all fields except the `leaf_secret` from its GroupState
-object.
+before the new user is added.
 
 [[ OPEN ISSUE: The Welcome message needs to be sent encrypted for
 the new member.  This should be done using the public key in the

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1161,7 +1161,8 @@ are revealed to the new member.
 
 Since the new member is expected to process the Add message for
 itself, the Welcome message should reflect the state of the group
-before the new user is added.
+before the new user is added. The sender of the Welcome message can
+simply copy all fields from their GroupState object.
 
 [[ OPEN ISSUE: The Welcome message needs to be sent encrypted for
 the new member.  This should be done using the public key in the


### PR DESCRIPTION
There is no "leaf_secret" field in GroupState. While there might be one in the group state struct that the implementation maintains locally, I think it's safe to recommend copying everything from the GroupState object as it's defined earlier in the document.