### PR TITLE
Some propositions for minor changes in structure and wording of the Handshake section.

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1057,7 +1057,8 @@ follows:
    is equal the `epoch` field of the current GroupState object.
 
 2. Use the `operation` message to produce an updated, provisional
-   GroupState object incorporating the proposed changes.
+   GroupState object incorporating the proposed changes as described in the
+   following sections.
 
 3. Look up the public key for slot index `signer_index` from the
    roster in the current GroupState object (before the update).
@@ -1119,6 +1120,8 @@ has computation and communication complexity O(N log N) instead of
 the O(N) complexity of direct initialization. ]]
 
 ## Add
+
+### Initiating an Add Operation
 
 In order to add a new member to the group, an existing member of the
 group must take two actions:
@@ -1193,8 +1196,10 @@ follows:
 * Prepare a new GroupState object based on the Welcome message
 * Process the Add message as an existing participant would
 
-An existing participant receiving a Add message first verifies
-the signature on the message,  then updates its state as follows:
+### Processing an Add Message
+
+An existing participant receiving a Add message creates a provisional group
+state by modifying a copy of the current group state as follows:
 
 * Increment the size of the group
 * Verify the signature on the included UserInitKey; if the signature
@@ -1217,6 +1222,8 @@ degrading into subtrees, and thus maintain the protocol's efficiency.
 
 ## Update
 
+### Initiating an Update Operation
+
 An Update message is sent by a group participant to update its leaf
 key pair.  This operation provides post-compromise security with
 regard to the participant's prior leaf private key.
@@ -1232,8 +1239,10 @@ The sender of an Update message creates it in the following way:
 * Generate a fresh leaf key pair
 * Compute its direct path in the current ratchet tree
 
-An existing participant receiving a Update message first verifies
-the signature on the message, then updates its state as follows:
+### Processing an Update Message
+
+An existing participant receiving an Update message creates a provisional group
+state by modifying a copy of the current group state as follows:
 
 * Update the cached ratchet tree by replacing nodes in the direct
   path from the updated leaf using the information contained in the
@@ -1243,6 +1252,8 @@ The update secret resulting from this change is the secret for the
 root node of the ratchet tree.
 
 ## Remove
+
+### Initiating a Remove Operation
 
 A Remove message is sent by a group member to remove one or more
 participants from the group.
@@ -1257,13 +1268,11 @@ struct {
 The sender of a Remove message generates it as as follows:
 
 * Generate a fresh leaf key pair
-* Compute its direct path in the current ratchet tree, starting from
-  the removed leaf
+* Compute its direct path in the current ratchet tree, as if performing an
+  update operation, replacing the removed leaf with the freshly generated one.
 
-An existing participant receiving a Remove message first verifies
-the signature on the message, then verifies its identity proof
-against the identity tree held by the participant.  The participant
-then updates its state as follows:
+An existing participant receiving a Remove message creates a provisional group
+state by modifying a copy of the current group state as follows:
 
 * Update the roster by setting the credential in the removed slot to
   the null optional value

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1206,11 +1206,13 @@ state by modifying a copy of the current group state as follows:
 * Increment the size of the group
 * Verify the signature on the included UserInitKey; if the signature
   verification fails, abort
-* Append an entry to the roster containing the credential in the
-  included UserInitKey
 * Update the ratchet tree by adding a new leaf node for the new
   member, containing the public key from the UserInitKey in the Add
   corresponding to the ciphersuite in use
+* Add an entry to the roster containing the credential in the
+  included UserInitKey such that its index matches is the index 
+  corresponds to the index of the leaf node added to the ratchet tree 
+  in the previous step
 * Update the ratchet tree by setting to blank all nodes in the
   direct path of the new node, except for the leaf (which remains
   set to the new member's public key)

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1121,6 +1121,8 @@ the O(N) complexity of direct initialization. ]]
 
 ## Add
 
+The Add operation allows group members to add new members to the group.
+
 ### Initiating an Add Operation
 
 In order to add a new member to the group, an existing member of the
@@ -1222,6 +1224,8 @@ degrading into subtrees, and thus maintain the protocol's efficiency.
 
 ## Update
 
+The Update operation allows group members to update their own leaf secrets.
+
 ### Initiating an Update Operation
 
 An Update message is sent by a group participant to update its leaf
@@ -1252,6 +1256,8 @@ The update secret resulting from this change is the secret for the
 root node of the ratchet tree.
 
 ## Remove
+
+The Remove operation allows group Members to remove members from the group.
 
 ### Initiating a Remove Operation
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1060,20 +1060,23 @@ follows:
    GroupState object incorporating the proposed changes as described in the
    following sections.
 
-3. Look up the public key for slot index `signer_index` from the
+3. Update the `transcript_hash` field of the provisional GroupState object as
+   described in the Group State section.
+
+4. Look up the public key for slot index `signer_index` from the
    roster in the current GroupState object (before the update).
 
-4. Use that public key to verify the `signature` field in the
+5. Use that public key to verify the `signature` field in the
    Handshake message, with the updated GroupState object as input.
 
-5. If the signature fails to verify, discard the updated GroupState
+6. If the signature fails to verify, discard the updated GroupState
    object and consider the Handshake message invalid.
 
-6. Use the `confirmation_key` for the new group state to
+7. Use the `confirmation_key` for the new group state to
    compute the finished MAC for this message, as described below,
    and verify that it is the same as the `finished_mac` field.
 
-7. If the the above checks are successful, consider the updated
+8. If the the above checks are successful, consider the updated
    GroupState object as the current state of the group.
 
 The `signature` and `confirmation` values are computed over the
@@ -1210,8 +1213,8 @@ state by modifying a copy of the current group state as follows:
   member, containing the public key from the UserInitKey in the Add
   corresponding to the ciphersuite in use
 * Add an entry to the roster containing the credential in the
-  included UserInitKey such that its index matches is the index 
-  corresponds to the index of the leaf node added to the ratchet tree 
+  included UserInitKey such that its index matches is the index
+  corresponds to the index of the leaf node added to the ratchet tree
   in the previous step
 * Update the ratchet tree by setting to blank all nodes in the
   direct path of the new node, except for the leaf (which remains


### PR DESCRIPTION
The handshake section felt a bit "flat" to me, so I introduced some more structure. Also, every section describing the handling of the individual message types mentioned verifying the signature, which was already covered in the general description of how to handle Handshake messages. I realize this Section might change somewhat with the generic framing approach, so feel free to ignore this particular PR, if you want to tackle these points there.

Update: I also found what I think is an small error in the instructions of how to process an Add message: The position of the newly added credential in the list of members has to match the position of the newly added leaf node in the tree. This necessitates that it happens _after_ the leaf node is added. The last commit updates the Add instructions accordingly.