### PR TITLE
Fixes to tree manipulation in Remove

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1139,14 +1139,6 @@ for the new member using HPKE.  The recipient key pair for the
 HPKE encryption is the one included in the indicated UserInitKey,
 corresponding to the indicated ciphersuite.
 
-We say a "pre-Add" GroupState is a GroupState that was created from a
-a WelcomeInfo object and has not yet received the corresponding Add
-message. A pre-Add GroupState does not have a defined signer key and
-its roster does not have an entry with the public key corresponding to
-the member's identity key. Thus, a pre-Add GroupState is incapable of
-processing Update and Remove messages. A member in a pre-Add state MAY
-therefore ignore all Handshake messages that are not an Add operation.
-
 ~~~~~
 struct {
   ProtocolVersion version;
@@ -1306,13 +1298,11 @@ state as follows:
 * Truncate the tree such that the rightmost non-blank leaf is the
   last node of the tree
 
-Note that there must be at least one non-null element in the roster.
-For if this GroupState is pre-Add, then it is incapable of processing
-a Remove operation at all. And if this GroupState is not pre-Add, then
-it must have the current member in the roster. Since self-removal is
-prohibited, at least 1 non-null element must remain. The same
-reasoning justifies the existence of a non-blank leaf in the ratchet
-tree.
+Note that there must be at least one non-null element in the roster,
+since any valid GroupState must have the current member in the roster
+and self-removal is prohibited. Thus, at least 1 non-null element must
+remain. The same reasoning justifies the existence of a non-blank leaf
+in the ratchet tree.
 
 The update secret resulting from this change is the secret for the
 root node of the ratchet tree after the second step (after the third

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1271,9 +1271,11 @@ root node of the ratchet tree.
 
 ## Remove
 
-A Remove message is sent by a group member to remove one or more
+A Remove message is sent by a group member to remove one or more other
 members from the group. A member MUST NOT use a Remove message to
-remove themselves from the group.
+remove themselves from the group. If a member of a group receives a
+Remove message where the removed index is equal to the signer index,
+the recipient MUST reject the message as malformed.
 
 ~~~~~
 struct {
@@ -1300,12 +1302,17 @@ state as follows:
   direct path of the removed leaf, and also setting the root node
   to blank
 * Truncate the roster such that the last roster element is
-  non-null (there must be at least one such an element, since a
-  pre-Add GroupState cannot process a Remove, a non-pre-Add GroupState
-  must have the current member in the roster, and self-removal is
-  prohibited)
+  non-null
 * Truncate the tree such that the rightmost non-blank leaf is the
-  last node of the tree (clearing the tree if no such leaf exists)
+  last node of the tree
+
+Note that there must be at least one non-null element in the roster.
+For if this GroupState is pre-Add, then it is incapable of processing
+a Remove operation at all. And if this GroupState is not pre-Add, then
+it must have the current member in the roster. Since self-removal is
+prohibited, at least 1 non-null element must remain. The same
+reasoning justifies the existence of a non-blank leaf in the ratchet
+tree.
 
 The update secret resulting from this change is the secret for the
 root node of the ratchet tree after the second step (after the third

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1288,7 +1288,8 @@ state as follows:
 * Update the ratchet tree by replacing nodes in the direct
   path from the removed leaf using the information in the Remove message
 * Update the ratchet tree by setting to blank all nodes in the
-  direct path of the removed leaf
+  direct path of the removed leaf, and also setting the root node
+  to blank
 * Truncate the roster such that the last roster element is
   non-null (clearing the roster if no such element exists)
 * Truncate the tree such that the rightmost non-blank leaf is the

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1298,11 +1298,11 @@ state as follows:
 * Truncate the tree such that the rightmost non-blank leaf is the
   last node of the tree
 
-Note that there must be at least one non-null element in the roster,
-since any valid GroupState must have the current member in the roster
-and self-removal is prohibited. Thus, at least 1 non-null element must
-remain. The same reasoning justifies the existence of a non-blank leaf
-in the ratchet tree.
+Note that, in step 4, there must be at least one non-null element in
+the roster, since any valid GroupState must have the current member in
+the roster and self-removal is prohibited. The same reasoning
+justifies the existence of a non-blank leaf in the ratchet tree in
+step 5.
 
 The update secret resulting from this change is the secret for the
 root node of the ratchet tree after the second step (after the third

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1139,6 +1139,12 @@ for the new member using HPKE.  The recipient key pair for the
 HPKE encryption is the one included in the indicated UserInitKey,
 corresponding to the indicated ciphersuite.
 
+We say a "pre-Add" GroupState is a GroupState that was created from a
+a WelcomeInfo object and has not yet received the corresponding Add
+message. A pre-Add GroupState is incapable of processing an Update or
+Remove message. Thus, a member in a pre-Add state MAY ignore all
+Handshake messages not an Add operation.
+
 ~~~~~
 struct {
   ProtocolVersion version;
@@ -1264,7 +1270,8 @@ root node of the ratchet tree.
 ## Remove
 
 A Remove message is sent by a group member to remove one or more
-members from the group.
+members from the group. A member MUST NOT use a Remove message to
+remove themselves from the group.
 
 ~~~~~
 struct {
@@ -1291,7 +1298,10 @@ state as follows:
   direct path of the removed leaf, and also setting the root node
   to blank
 * Truncate the roster such that the last roster element is
-  non-null (clearing the roster if no such element exists)
+  non-null (there must be at least one such an element, since a
+  pre-Add GroupState cannot process a Remove, a non-pre-Add GroupState
+  must have the current member in the roster, and self-removal is
+  prohibited)
 * Truncate the tree such that the rightmost non-blank leaf is the
   last node of the tree (clearing the tree if no such leaf exists)
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1287,10 +1287,12 @@ state as follows:
   the null optional value
 * Update the ratchet tree by replacing nodes in the direct
   path from the removed leaf using the information in the Remove message
-* Reduce the size of the roster and the tree until the rightmost
-  element roster element and leaf node are non-null
 * Update the ratchet tree by setting to blank all nodes in the
   direct path of the removed leaf
+* Truncate the roster such that the last roster element is
+  non-null (clearing the roster if no such element exists)
+* Truncate the tree such that the rightmost non-blank leaf is the
+  last node of the tree (clearing the tree if no such leaf exists)
 
 The update secret resulting from this change is the secret for the
 root node of the ratchet tree after the second step (after the third

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1141,9 +1141,11 @@ corresponding to the indicated ciphersuite.
 
 We say a "pre-Add" GroupState is a GroupState that was created from a
 a WelcomeInfo object and has not yet received the corresponding Add
-message. A pre-Add GroupState is incapable of processing an Update or
-Remove message. Thus, a member in a pre-Add state MAY ignore all
-Handshake messages not an Add operation.
+message. A pre-Add GroupState does not have a defined signer key and
+its roster does not have an entry with the public key corresponding to
+the member's identity key. Thus, a pre-Add GroupState is incapable of
+processing Update and Remove messages. A member in a pre-Add state MAY
+therefore ignore all Handshake messages that are not an Add operation.
 
 ~~~~~
 struct {


### PR DESCRIPTION
This clears up the wording around how to prune the ratchet tree on a Remove operation. Previously, it could be interpreted as "remove nodes from the tree until the rightmost node is not null", but this is not what is intended by the authors, and it also has the ability to produce invalid trees (i.e., trees with an even number of elements).

The second change is to do the truncation _after_ doing the Blank propogation up the direct path of the removed leaf. Note that the order of these steps doesn't matter in that they produce the same resulting tree. However, if we blank after pruning, an implementor would have to take care to not to try to blank out previously-removed nodes. Prune-then-blank is a little easier to reason about.

The third change is a semantic fix. It is clear from the last paragraph in this section that the root node should be blanked, but the text only said to blank the direct path of the leaf, which does not include the root node. I just added that part in.