### PR TITLE
Added that users SHOULD verify pubkeys in an Update

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -637,13 +637,13 @@ The recipient of an update processes it with the following steps:
     the private key from the resolution node
   * Derive secret values for ancestors of that node using the KDF keyed with the
     decrypted secret
+  * Members MUST verify that the received public keys agree with the
+    public keys derived from the new node_secret values
 2. Merge the updated secrets into the tree
   * Replace the public keys for nodes on the direct path with the
     received public keys
   * For nodes where an updated secret was computed in step 1,
     replace the secret value for the node with the updated value
-  * Members MUST verify that the received public keys agree with the
-    public keys derived from the new node_secret values
 
 For example, suppose we had the following tree:
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -637,7 +637,7 @@ The recipient of an update processes it with the following steps:
     the private key from the resolution node
   * Derive secret values for ancestors of that node using the KDF keyed with the
     decrypted secret
-  * The recipient MUST verify that the received public keys agree with the
+  * The recipient SHOULD verify that the received public keys agree with the
     public keys derived from the new node_secret values
 2. Merge the updated secrets into the tree
   * Replace the public keys for nodes on the direct path with the

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -642,6 +642,8 @@ The recipient of an update processes it with the following steps:
     received public keys
   * For nodes where an updated secret was computed in step 1,
     replace the secret value for the node with the updated value
+  * Members MUST verify that the received public keys agree with the
+    public keys derived from the new node_secret values
 
 For example, suppose we had the following tree:
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -637,7 +637,7 @@ The recipient of an update processes it with the following steps:
     the private key from the resolution node
   * Derive secret values for ancestors of that node using the KDF keyed with the
     decrypted secret
-  * Members MUST verify that the received public keys agree with the
+  * The recipient MUST verify that the received public keys agree with the
     public keys derived from the new node_secret values
 2. Merge the updated secrets into the tree
   * Replace the public keys for nodes on the direct path with the


### PR DESCRIPTION
Adding this check would be the first step in recognizing that an Update operation may have maliciously excluded a person from the group.