### PR TITLE
Confirmation and transcript improvements

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -135,6 +135,13 @@ shared keys with costs that scale as the log of the group size.
 
 RFC EDITOR PLEASE DELETE THIS SECTION.
 
+draft-06
+
+- Resolve the circular dependency that draft-05 introduced in the
+  confirmation MAC calculation (\*)
+
+- Cover the entire MLSPlaintext in the transcript hash (\*)
+
 draft-05
 
 - Common framing for handshake and application messages (\*)

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -969,7 +969,7 @@ struct {
   opaque group_id<0..255>;
   uint32 epoch;
   uint32 sender;
-  ContentType content_type;
+  ContentType content_type = handshake;
   GroupOperation operation;
 } MLSPlaintextOpContent;
 
@@ -981,6 +981,14 @@ struct {
 intermediate_hash_[n] = Hash(transcript_hash_[n-1] || MLSPlaintextOpAuthData_[n-1]);
 transcript_hash_[n] = Hash(intermediate_hash_[n] || MLSPlaintextOpContent_[n]);
 ~~~~~
+
+This structure incorporates everything in an MLSPlaintext up to the
+confirmation field in the transcript that is included in that
+confirmation field (via the GroupState).  The confirmation and
+signature fields are then included in the transcript for the next
+operation.  The intermediate hash enables implementations to in
+corporate a plaintext into the transcript without having to store the
+whole MLSPlaintextOpAuthData structure.
 
 When a new one-member group is created (which requires no
 GroupOperation), the `transcript_hash` field is set to an all-zero


### PR DESCRIPTION
This PR addresses two issues that were noted in draft-05, one that is definitely a bug, and one that should improve security analysis.

* In draft-05, a circular dependency was introduced, wherein the confirmation MAC was calculated from the transcript, which includes the GroupOperation, which includes the confirmation MAC.  Here we move the confirmation MAC up to the MLSPlaintext object to avoid this circularity.

* In all prior versions, the transcript covered only the GroupOperation objects, not the sender metadata or signatures.  Here we cover the whole MLSPlaintext object, but in "staggered" form -- the confirmation MAC and signature aren't entered into the transcript until the next epoch.

Fixes #157 