### PR TITLE
Specify an Init message

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1501,7 +1501,7 @@ struct {
   opaque group_id<0..255>;
   ProtocolVersion version;
   CipherSuite cipher_suite;
-  UserInitKey members<0..2^32-1>;
+  ClientInitKey members<0..2^32-1>;
   DirectPath path;
 } Init;
 ~~~~~
@@ -1524,10 +1524,16 @@ the Init message as follows:
 * Construct a ratchet tree as above
 * Update the cached ratchet tree by replacing nodes in the direct
   path from the first leaf using the direct path
+* Update the cached ratchet tree by replacing nodes in the direct
+  path from the first leaf using the information contained in the
+  "path" attribute
 
 The update secret for this interaction, used with an all-zero init
 secret to generate the first epoch secret, is the `path_secret[i+1]`
-derived from the `path_secret[i]` associated to the root node.
+derived from the `path_secret[i]` associated to the root node.  The
+members learn the relevant path secrets by decrypting one of the
+encrypted path secrets in the DirectPath and working back to the
+root (as in normal DirectPath processing).
 
 ## Add
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1535,6 +1535,14 @@ members learn the relevant path secrets by decrypting one of the
 encrypted path secrets in the DirectPath and working back to the
 root (as in normal DirectPath processing).
 
+[[ OPEN ISSUE: This approach leaks the initial contents of the tree
+to the Delivery Service, unlike the sequential-Add case. ]]
+
+[[ OPEN ISSUE: It might be desireable for the group creator to be
+able to "pre-warm" the tree, by providing values for some nodes not
+on its direct path.  This would violate the tree invariant, so we
+would need to figure out what mitigations would be necessary. ]]
+
 ## Add
 
 In order to add a new member to the group, an existing member of the

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1472,9 +1472,9 @@ The creator of the group constructs an Init message as follows:
 * Fetch a UserInitKey for each member (including the creator)
 * Identify a protocol version and cipher suite that is supported by
   all proposed members.
-* Construct a ratchet tree with its first leaf blank, the remaining
-  leaves populated with the public keys and credentials from the
-  UserInitKeys of the members, and all other nodes blank.
+* Construct a ratchet tree with its leaves populated with the public
+  keys and credentials from the UserInitKeys of the members, and all
+  other nodes blank.
 * Generate a fresh leaf key pair for the first leaf
 * Compute its direct path in this ratchet tree
 


### PR DESCRIPTION
This is something we've been meaning to do for a while, and just haven't gotten around to.

The Init message directly creates a group with a specified member list.  The cost of group creation is O(N) DH operations for the sender, and O(1) for receivers.