### PR TITLE
DirectPathNode contains encrypted node secrets, not path secrets

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -991,7 +991,7 @@ struct {
 
 struct {
     HPKEPublicKey public_key;
-    HPKECiphertext encrypted_path_secrets<0..2^16-1>;
+    HPKECiphertext node_secrets<0..2^16-1>;
 } DirectPathNode;
 
 struct {


### PR DESCRIPTION
The paragraph below the changed field refers to `node_secrets`, not `encrypted_path_secrets`.