### PR TITLE
Formatting: removed `\_` where it was syntactically incorrect

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -999,9 +999,9 @@ struct {
 } DirectPath;
 ~~~~~
 
-The length of the `node\_secrets` vector MUST be zero for the first
+The length of the `node_secrets` vector MUST be zero for the first
 node in the path.  For the remaining elements in the vector, the
-number of ciphertexts in the `node\_secrets` vector MUST be equal to
+number of ciphertexts in the `node_secrets` vector MUST be equal to
 the length of the resolution of the corresponding copath node.  Each
 ciphertext in the list is the encryption to the corresponding node
 in the resolution.
@@ -1339,11 +1339,11 @@ are encoded in the following form:
 
 ~~~~~
 struct {
-    opaque content[length\_of\_content];
+    opaque content[length_of_content];
     uint8 signature[MLSCiphertextContent.sig_len];
     uint16 sig_len;
     uint8  marker = 1;
-    uint8  zero\_padding[length\_of\_padding];
+    uint8  zero_padding[length_of_padding];
 } MLSCiphertextContent;
 ~~~~~
 
@@ -1444,7 +1444,7 @@ arrived at the same state of the group:
 
 ~~~~~
 GroupOperation.confirmation =
-    HMAC(confirmation_key, GroupContext.transcript\_hash)
+    HMAC(confirmation_key, GroupContext.transcript_hash)
 ~~~~~
 
 HMAC {{!RFC2104}} uses the Hash algorithm for the ciphersuite in


### PR DESCRIPTION
The underscore character does not have to be escaped in code environments. This applies to the inline (backticks) as well as block (tildes) variants.