### PR TITLE
Add Beurdouche as a co-author

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -16,6 +16,10 @@ author:
     name: Richard Barnes
     organization: Cisco
     email: rlb@ipv.sx
+ -  ins: B. Beurdouche
+    name: Benjamin Beurdouche
+    organization: Inria
+    email: benjamin.beurdouche@inria.fr
  -
     ins: J. Millican
     name: Jon Millican


### PR DESCRIPTION
@beurdouche has been doing a lot of work, and I just noticed he's not on the list of co-authors.  In addition to recognizing his contribution, this will enable him to push new Internet-Draft versions.