### PR TITLE
Enable new joiners to decrypt an encrypted Add message

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1520,7 +1520,10 @@ needs to initialize a GroupContext object that can be updated to the
 current state using the Add message.  This information is encrypted
 for the new member using HPKE.  The recipient key pair for the
 HPKE encryption is the one included in the indicated ClientInitKey,
-corresponding to the indicated ciphersuite.
+corresponding to the indicated ciphersuite.  The "add_key_nonce"
+field contains the key and nonce used to encrypt the corresponding
+Add message; if it is not encrypted, then this field MUST be set to
+the null optional value.
 
 ~~~~~
 struct {
@@ -1529,12 +1532,18 @@ struct {
 } RatchetNode;
 
 struct {
+    opaque key<0..255>;
+    opaque nonce<0..255>;
+} KeyAndNonce;
+
+struct {
     ProtocolVersion version;
     opaque group_id<0..255>;
     uint32 epoch;
     optional<RatchetNode> tree<1..2^32-1>;
     opaque transcript_hash<0..255>;
     opaque init_secret<0..255>;
+    optional<KeyAndNonce> add_key_nonce;
 } WelcomeInfo;
 
 struct {


### PR DESCRIPTION
Prior drafts enabled encryption of handshake messages, via the common framing structure.  This had the unfortunate effect of making it impossible to add new members!  If an Add is sent encrypted, then the new joiner had no way to get the key to decrypt it.

This PR adds the key and nonce for the Add encryption to the corresponding WelcomeInfo structure.  This maintains the confidentiality of the Add because the WelcomeInfo is encrypted to the new joiner, while providing the new joiner the key material it needs to decrypt the Add.