### PR TITLE
Non-destructive add

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1593,6 +1593,9 @@ leaf in the tree, for the second Add, the next empty leaf to the right, etc.
 * If necessary, extend the tree to the right until it has at least index + 1
   leaves
 
+* For each intermediate node along the path from the leaf at position `index` to
+  the root, add `index` to the `unmerged_leaves` list for the node.
+
 * Blank the path from the leaf at position `index` to the root
 
 * Set the leaf node in the tree at position `index` to a new node containing the


### PR DESCRIPTION
This PR attempts to implement the "non-destructive add" proposal discussed at IETF 105.  Instead of blanking nodes on add, we keep track of "unmerged leaves" below each intermediate node.  This involves a bit more complexity in the tree state that is passed around, but avoids unnecessary blank nodes.