### PR TITLE
Add authenticated_data to the mls message.

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1351,6 +1351,7 @@ struct {
     uint32 epoch;
     ContentType content_type;
     opaque sender_data_nonce<0..255>;
+    opaque authenticated_data<0..2^32-1>;
 } MLSCiphertextSenderDataAAD;
 ~~~~~
 
@@ -1405,8 +1406,8 @@ struct {
     uint32 epoch;
     ContentType content_type;
     opaque sender_data_nonce<0..255>;
-    opaque encrypted_sender_data<0..255>;
     opaque authenticated_data<0..2^32-1>;
+    opaque encrypted_sender_data<0..255>;
 } MLSCiphertextContentAAD;
 ~~~~~
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1291,9 +1291,9 @@ struct {
     opaque group_id<0..255>;
     uint32 epoch;
     ContentType content_type;
+    opaque authenticated_data<0..2^32-1>;
     opaque sender_data_nonce<0..255>;
     opaque encrypted_sender_data<0..255>;
-    opaque authenticated_data<0..2^32-1>;
     opaque ciphertext<0..2^32-1>;
 } MLSCiphertext;
 ~~~~~
@@ -1350,8 +1350,8 @@ struct {
     opaque group_id<0..255>;
     uint32 epoch;
     ContentType content_type;
-    opaque sender_data_nonce<0..255>;
     opaque authenticated_data<0..2^32-1>;
+    opaque sender_data_nonce<0..255>;
 } MLSCiphertextSenderDataAAD;
 ~~~~~
 
@@ -1405,8 +1405,8 @@ struct {
     opaque group_id<0..255>;
     uint32 epoch;
     ContentType content_type;
-    opaque sender_data_nonce<0..255>;
     opaque authenticated_data<0..2^32-1>;
+    opaque sender_data_nonce<0..255>;
     opaque encrypted_sender_data<0..255>;
 } MLSCiphertextContentAAD;
 ~~~~~

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1263,6 +1263,7 @@ struct {
     uint32 epoch;
     uint32 sender;
     ContentType content_type;
+    opaque authenticated_data<0..2^32-1>;
 
     select (MLSPlaintext.content_type) {
         case handshake:
@@ -1273,7 +1274,6 @@ struct {
             opaque application_data<0..2^32-1>;
     }
 
-    opaque authenticated_data<0..2^32-1>;
     opaque signature<0..2^16-1>;
 } MLSPlaintext;
 
@@ -1390,7 +1390,7 @@ struct {
     ContentType content_type;
     opaque sender_data_nonce<0..255>;
     opaque encrypted_sender_data<0..255>;
-    opaque authenticated_content[length_of_authenticated_content];
+    opaque authenticated_data<0..2^32-1>;
 } MLSCiphertextContentAAD;
 ~~~~~
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1273,6 +1273,7 @@ struct {
             opaque application_data<0..2^32-1>;
     }
 
+    opaque authenticated_data<0..2^32-1>;
     opaque signature<0..2^16-1>;
 } MLSPlaintext;
 
@@ -1282,6 +1283,7 @@ struct {
     ContentType content_type;
     opaque sender_data_nonce<0..255>;
     opaque encrypted_sender_data<0..255>;
+    opaque authenticated_data<0..2^32-1>;
     opaque ciphertext<0..2^32-1>;
 } MLSCiphertext;
 ~~~~~
@@ -1299,7 +1301,7 @@ The overall process is as follows:
   * Key generation
 
 * Sign the plaintext metadata -- the group ID, epoch, sender index, and
-  content type -- as well as the message content
+  content type -- as well as the authenticated data and message content
 
 * Randomly generate sender_data_nonce and encrypt the sender information
   using it and the key derived from the sender_data_secret
@@ -1307,8 +1309,8 @@ The overall process is as follows:
 * Encrypt the content using a content encryption key identified by
   the metadata
 
-The group identifier, epoch and content_type fields are copied from
-the MLSPlaintext object directly.
+The group identifier, epoch, content_type and authenticated data fields
+are copied from the MLSPlaintext object directly.
 The content encryption process populates the ciphertext field of the
 MLSCiphertext object.  The metadata encryption step populates the
 encrypted_sender_data field.
@@ -1388,6 +1390,7 @@ struct {
     ContentType content_type;
     opaque sender_data_nonce<0..255>;
     opaque encrypted_sender_data<0..255>;
+    opaque authenticated_content[length_of_authenticated_content];
 } MLSCiphertextContentAAD;
 ~~~~~
 


### PR DESCRIPTION
[As previously discussed](https://mailarchive.ietf.org/arch/msg/mls/jB5ygAJs3P8TLkduj6Q9vFWmSJI), this is a proposal to add AAD to the application messages.

There are many motivations to do this:
• It's a 'cheap' feature to add (although it could potentially be misused)
• It avoids duplicate content: if there is a content that needs to be authenticated, but also needs to be visible to the server, the only solution today is to repeat it in the header (to the server) and then in the encrypted body.
• Modern ciphers already provide support for AAD, and MLS takes advantage of this. In fact most(all?) of the fields in the header are authenticated already.
• This field is optional(as in: can be empty), which means that it doesn't have to be used in the implementation.

The primary benefit is for the server to have access to the fields that are otherwise authenticated, but are not part of MLS message. Typically, the server has another encryption mechanism with the client (e.g. TLS) and as such client-server communication is already secure. As a matter of fact, handshake messages can already be transported in plaintext (in case server needs to examine their content), but application messages are not allowed to have any plaintext content, even though server may need to examine some metadata as well.

A couple of thoughts that may be worth discussing: 
* what should be the max size of authenticated_data (I assumed 32KB, just like application message)
* whether *authenticated data* should be offered only as part of *application*, or both *handshake message* and *application message*. It is fair to consider it only for an *application message*, though for simplicity I added it to both message types. Happy to change it based on general preferences.