### PR TITLE
Favor not reusing ClientInitKey reuse (SHOULD)

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1213,8 +1213,8 @@ A ClientInitKey object specifies a ciphersuite that the client
 supports, as well as providing a public key that others can use
 for key agreement. The client's identity key is intended to be
 stable throughout the lifetime of the group; there is no mechanism to
-change it.  Init keys are intended to be used only once and SHOULD
-not be reused except in case of last resort. (See {{init-key-reuse}}).
+change it.  Init keys are intended to be used only once and SHOULD NOT
+be reused except in case of last resort. (See {{init-key-reuse}}).
 Clients MAY generate and publish multiple ClientInitKey objects to
 support multiple ciphersuites.
 ClientInitKeys contain an identifier chosen by the client, which the

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1213,10 +1213,10 @@ A ClientInitKey object specifies a ciphersuite that the client
 supports, as well as providing a public key that others can use
 for key agreement. The client's identity key is intended to be
 stable throughout the lifetime of the group; there is no mechanism to
-change it.  Init keys are intended to be used only once.
-(See {{init-key-reuse}}). Clients MAY
-generate and publish multiple ClientInitKey objects to support multiple
-ciphersuites.
+change it.  Init keys are intended to be used only once and SHOULD
+not be reused except in case of last resort. (See {{init-key-reuse}}).
+Clients MAY generate and publish multiple ClientInitKey objects to
+support multiple ciphersuites.
 ClientInitKeys contain an identifier chosen by the client, which the
 client MUST assure uniquely identifies a given ClientInitKey object
 among the set of ClientInitKeys created by this client.

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1213,10 +1213,10 @@ A ClientInitKey object specifies a ciphersuite that the client
 supports, as well as providing a public key that others can use
 for key agreement. The client's identity key is intended to be
 stable throughout the lifetime of the group; there is no mechanism to
-change it.  Init keys are intended to be used a very limited number of
-times, ideally only once. (See {{init-key-reuse}}). Clients MAY
+change it.  Init keys are intended to be used only once.
+(See {{init-key-reuse}}). Clients MAY
 generate and publish multiple ClientInitKey objects to support multiple
-ciphersuites, or to reduce the likelihood of init key reuse.
+ciphersuites.
 ClientInitKeys contain an identifier chosen by the client, which the
 client MUST assure uniquely identifies a given ClientInitKey object
 among the set of ClientInitKeys created by this client.
@@ -2203,8 +2203,7 @@ derived secrets.
 ## Init Key Reuse
 
 Initialization keys are intended to be used only once and then
-deleted. Reuse of init keys is not believed to be inherently insecure
-{{dhreuse}}, although it can complicate protocol analyses.
+deleted. Reuse of init keys can lead to replay attacks.
 
 
 # IANA Considerations


### PR DESCRIPTION
This has been reported unclear multiple times. I strongly prefer forbidding reuse altogether.
A validation mechanism is needed for the formal security proof, it can be implemented according to an expiration mechanism (see Architecture - 4.2.  Delivery Service Compromise)