### PR TITLE
Bugfixes in ClientInitKey, Commit, and Welcome

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1314,10 +1314,9 @@ struct {
 } Extension;
 
 struct {
-    ProtocolVersion supported_version;
-    opaque client_init_key_id<0..255>;
+    ProtocolVersion version;
     CipherSuite cipher_suite;
-    HPKEPublicKey init_key;
+    HPKEPublicKey leaf_key;
     Credential credential;
     Extension extensions<0..2^16-1>;
     opaque signature<0..2^16-1>;

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1072,7 +1072,6 @@ struct {
   uint32 epoch;
   uint32 sender;
   ContentType content_type = commit;
-  Proposal proposals<0..2^32-1>;
   Commit commit;
 } MLSPlaintextCommitContent;
 
@@ -1395,10 +1394,9 @@ struct {
           opaque application_data<0..2^32-1>;
 
         case proposal:
-          Proposal proposals<1..2^32-1>;
+          Proposal proposals;
 
         case commit:
-          Proposal proposals<1..2^32-1>;
           Commit commit;
           opaque confirmation<0..255>;
     }
@@ -1785,16 +1783,10 @@ the sender of the proposal can retransmit the Proposal in the new epoch.
 
 Each proposal covered by the Commit is identified by a ProposalID structure.
 The `plaintext_hash` field contains the hash of the MLSPlaintext in which the
-Proposal was sent, and the `index` field contains the index of the proposal in
-the `proposals` array in the MLSPlaintext.  For proposals sent in the same
-MLSPlaintext as a Commit, the `plaintext_hash` value MUST be the zero-length
-octet string.
+Proposal was sent.
 
 ~~~~~
-struct {
-    opaque plaintext_hash<0..255>;
-    uint16 index;
-} ProposalID;
+opaque ProposalID<0..255>;
 
 struct {
     ProposalID updates<0..2^16-1>;

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1315,7 +1315,7 @@ struct {
 struct {
     ProtocolVersion version;
     CipherSuite cipher_suite;
-    HPKEPublicKey leaf_key;
+    HPKEPublicKey init_key;
     Credential credential;
     Extension extensions<0..2^16-1>;
     opaque signature<0..2^16-1>;

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1926,8 +1926,8 @@ struct {
 struct {
   ProtocolVersion version = mls10;
   CipherSuite cipher_suite;
-  EncryptedKeyPackage key_packages<1..V>;
-  opaque encrypted_group_info;
+  EncryptedKeyPackage key_packages<1..2^32-1>;
+  opaque encrypted_group_info<1..2^32-1>;
 } Welcome;
 ~~~~~
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1785,15 +1785,16 @@ because the sender of the Commit did not receive the Proposal.  In such cases,
 the sender of the proposal can retransmit the Proposal in the new epoch.
 
 Each proposal covered by the Commit is identified by a ProposalID structure.
-The `sender` field in this structure indicates the member of the group that sent
-the proposal (according to their index in the ratchet tree).  The `hash` field
-contains the hash of the MLSPlaintext in which the Proposal was sent, using the
-hash function for the group's ciphersuite.
+The `plaintext_hash` field contains the hash of the MLSPlaintext in which the
+Proposal was sent, and the `index` field contains the index of the proposal in
+the `proposals` array in the MLSPlaintext.  For proposals sent in the same
+MLSPlaintext as a Commit, the `plaintext_hash` value MUST be the zero-length
+octet string.
 
 ~~~~~
 struct {
-    uint32 sender;
-    opaque hash<0..255>;
+    opaque plaintext_hash<0..255>;
+    uint16 index;
 } ProposalID;
 
 struct {

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1005,6 +1005,7 @@ enum {
     supported_versions(1),
     supported_ciphersuites(2),
     expiration(3),
+    key_id(4),
     (65535)
 } ExtensionType;
 
@@ -1014,8 +1015,7 @@ struct {
 } Extension;
 
 struct {
-    ProtocolVersion supported_version;
-    opaque client_init_key_id<0..255>;
+    ProtocolVersion version;
     CipherSuite cipher_suite;
     HPKEPublicKey hpke_init_key;
     Credential credential;
@@ -1065,6 +1065,16 @@ an expiration time.  In particular, applications that rely on "last resort"
 ClientInitKeys to ensure continued reachability may choose to omit the
 expiration extension from these keys, or give them much longer lifetimes than
 other ClientInitKeys.
+
+## ClientInitKey Identifiers
+
+Within MLS, a ClientInitKey is identified by its hash (see, e.g.,
+{{welcoming-new-members}}).  The `key_id` extension allows applications to add
+an explicit, application-defined identifier to a ClientInitKey.
+
+~~~~~
+opaque key_id<0..2^16-1>;
+~~~~~
 
 ## Tree Hashes and Signatures
 


### PR DESCRIPTION
1. The `client_init_key_id` is no longer needed, since CIKs are referenced by hash.
2. ProposalIDs were no longer usable to refer to proposals since we enabled multiple proposals per MLSPlaintext
3. The syntax description for Welcome was invalid