### PR TITLE
Welcome confirmation and key derivation

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1908,6 +1908,8 @@ struct {
   opaque interim_transcript_hash<0..255>;
   opaque epoch_secret<0..255>;
 
+  opaque confirmation<0..255>;
+
   uint32 signer_index;
   opaque signature<0..255>;
 } GroupInfo;
@@ -1962,6 +1964,10 @@ On receiving a Welcome message, a client processes it using the following steps:
 
 * Construct a new group state using the information in the GroupInfo object.
   The new member's position in the tree is `index`, as defined above.
+
+* Verify the confirmation value by deriving the `confirmation_key` from the
+  provided `epoch_secret` and the constructed group state, and computing the MAC
+  over the provided confirmed_transcript_hash (as shown in {{commit}})
 
 * Identify the lowest node at which the direct paths from `index` and
   `signer_index` overlap.  Set private keys for that node and its parents up to


### PR DESCRIPTION
1. Once a new member instantiates the group state, they can verify the confirmation MAC that was sent in the Commit that created the state.  This lets new members verify that they've joined correctly.  (It does not assure that they're seeing the same confirmation as anyone else.)

2. Instead of generating a fresh key, we can simply provide the epoch key in the key package and derive the GroupInfo encryption key from it.  This avoids relying on fresh entropy, and makes it more difficult for the sender to provide different keys that will all decrypt and authenticate the GroupInfo.