### PR TITLE
Change special values to structed types for external senders

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1446,8 +1446,8 @@ enum {
 enum {
     invalid(0),
     member(1),
-    external_authority(2),
-    external_self(3),
+    preconfigured(2),
+    new_member(3),
     (255)
 } SenderType;
 
@@ -1810,32 +1810,33 @@ A member of the group applies a Remove message by taking the following steps:
 
 * Blank the intermediate nodes along the path from the removed leaf to the root
 
-### External Proposals {#external-proposals}
+### External Proposals
 
 Add and Remove proposals can be constructed and sent to the group by a party
 that is outside the group.  For example, a Delivery Service might propose to
 remove a member of a group has been inactive for a long time, or propose adding
 a newly-hired staff member to a group representing a real-world team.  Proposals
-originating outside the group are identified by an `external` SenderType in
-MLSPlaintext.
+originating outside the group are identified by an `preconfigured` or
+`new_member` SenderType in MLSPlaintext.
 
-The `external_self` SenderType is used for clients proposing that they
-themselves be added.  For this ID type the sender value is ignored.  Proposals
-with types other than Add MUST NOT be sent with this sender type.  In such
-cases, the MLSPlaintext MUST be signed with the private key corresponding to the
+The `new_member` SenderType is used for clients proposing that they themselves
+be added.  For this ID type the sender value MUST be zero.  Proposals with types
+other than Add MUST NOT be sent with this sender type.  In such cases, the
+MLSPlaintext MUST be signed with the private key corresponding to the
 ClientInitKey in the Add message.  Recipients MUST verify that the MLSPlaintext
 carrying the Proposal message is validly signed with this key.
 
-The `external_authority` SenderType is reserved for signers that are
-pre-provisioned to the clients within a group.  If proposals with these sender
-IDs are to be accepted within a group, the members of the group MUST be
-provisioned by the application with a mapping between these IDs and authorized
-signing keys.  To ensure consistent handling of external proposals, the
-application MUST ensure that the members of a group have the same mapping
-and apply the same policies to external proposals.
+The `preconfigured` SenderType is reserved for signers that are pre-provisioned
+to the clients within a group.  If proposals with these sender IDs are to be
+accepted within a group, the members of the group MUST be provisioned by the
+application with a mapping between these IDs and authorized signing keys.  To
+ensure consistent handling of external proposals, the application MUST ensure
+that the members of a group have the same mapping and apply the same policies to
+external proposals. 
 
-An external proposal MUST be sent as an MLSPlaintext object, since the sender
-will not have the keys necessary to construct an MLSCiphertext object.
+An external proposal MUST be sent as an MLSPlaintext
+object, since the sender will not have the keys necessary to construct an
+MLSCiphertext object.
 
 [[ TODO: Should recognized external signers be added to some object that the
 group explicitly agrees on, e.g., as an extension to the GroupContext? ]]


### PR DESCRIPTION
Action item from Singapore: it seems better to specify directly in the message if we have an external sender instead of using reserved ranges.