### PR TITLE
Flesh out the extensions story

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2260,7 +2260,7 @@ handle extensible fields:
 * A client adding a new member to a group MUST verify that the ClientInitKey
   for the new member contains extensions that are consistent with the group's
   extensions.  For each extension in the GroupContext, the ClientInitKey MUST
-  have an extension of the same type, and the contents of the extensionn MUST be
+  have an extension of the same type, and the contents of the extension MUST be
   consistent with the value of the extension in the GroupContext, according to
   the semantics of the specific extension.
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2152,7 +2152,7 @@ welcome_key = HKDF-Expand(welcome_secret, "key", key_length)
 * Verify the confirmation MAC in the GroupInfo using the derived confirmation
   key and the `confirmed_transcript_hash` from the GroupInfo.
 
-# Extensibility and Invariants
+# Extensibility
 
 This protocol includes a mechanism for negotiating extension parameters similar
 to one in TLS {{RFC8446}}.  In TLS, extension negotiation is one-to-one.  The
@@ -2171,9 +2171,7 @@ places:
 In other words, clients advertise their capabilities in ClientInitKey
 extensions, the creator of the group expresses its choices for the group in
 Welcome extensions, and the GroupContext confirms that all members of the group
-have the same view of the group's extensions.  This document does not define any
-way for the parameters of the group to change once it has been created; such a
-behavior could be implemented as an extension.
+have the same view of the group's extensions.
 
 This extension mechanism is designed to allow for secure and forward-compatible
 negotiation of extensions.  For this to work, implementations MUST correctly
@@ -2186,6 +2184,12 @@ handle extensible fields:
 * A client initiating a group MUST ignore all unrecognized ciphersuites,
   extensions, and other parameters.  Otherwise, it may fail to interoperate with
   newer clients.
+
+* A client joining a group MUST populate the GroupContext extensions with
+  exactly the contents of the extensions field in the Welcome message.
+
+This document does not define any way for the parameters of the group to change
+once it has been created; such a behavior could be implemented as an extension.
 
 [[ OPEN ISSUE: Should we put bounds on what an extension can change?  For
 example, should we make an explicit guarantee that as long as you're speaking

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2227,14 +2227,14 @@ welcome_key = HKDF-Expand(welcome_secret, "key", key_length)
 # Extensibility
 
 This protocol includes a mechanism for negotiating extension parameters similar
-to one in TLS {{RFC8446}}.  In TLS, extension negotiation is one-to-one.  The
-client offers extensions in its ClientHello message, and the server expersses
+to the one in TLS {{RFC8446}}.  In TLS, extension negotiation is one-to-one: The
+client offers extensions in its ClientHello message, and the server expresses
 its choices for the session with extensions in its ServerHello and
 EncryptedExtensions messages.  In MLS, extensions appear in the following
 places:
 
 * In ClientInitKeys, to describe client capabilities and aspects of their
-  particiation in the group (once in the ratchet tree)
+  participation in the group (once in the ratchet tree)
 * In the Welcome message, to tell new members of a group what parameters are
   being used by the group
 * In the GroupContext object, to ensure that all members of the group have the
@@ -2257,8 +2257,22 @@ handle extensible fields:
   extensions, and other parameters.  Otherwise, it may fail to interoperate with
   newer clients.
 
+* A client adding a new member to a group MUST verify that the ClientInitKey
+  for the new member contains extensions that are consistent with the group's
+  extensions.  For each extension in the GroupContext, the ClientInitKey MUST
+  have an extension of the same type, and the contents of the extensionn MUST be
+  consistent with the value of the extension in the GroupContext, according to
+  the semantics of the specific extension.
+
 * A client joining a group MUST populate the GroupContext extensions with
-  exactly the contents of the extensions field in the Welcome message.
+  exactly the contents of the extensions field in the Welcome message.  If any
+  extension is unrecognized (i.e., not contained in the corresponding
+  ClientInitKey), then the client MUST reject the Welcome message and not join
+  the group.
+
+Note that the latter two requirements mean that all MLS extensions are
+mandatory, in the sense that an extension in use by the group MUST be supported
+by all members of the group.
 
 This document does not define any way for the parameters of the group to change
 once it has been created; such a behavior could be implemented as an extension.


### PR DESCRIPTION
Extensions in the CIK were only half of the story.  To do things like RTreeKEM or fork/merge as extensions, we need the ability to (1) tell new members that the group is doing something different, and (2) confirm that all group members have the same view of the rules of the road.  This PR adds extensions to the GroupInfo object for the first case, and to the Welcome object for the second, and a bunch of explanatory text to make it all work.

One thing this PR does *not* do is define a way to change extensions in a running group.  You could in principle do this by sending new extensions in Commit that could overwrite or add to extensions.  But that entails some messy questions (how do you delete an extension in use?), so it is currently left to an extension (heh), or to a group restart.

Depends on #295 to avoid conflicts in GroupInfo changes.