### PR TITLE
Remove nonce from SenderData AAD.

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1580,8 +1580,7 @@ struct {
     uint64 epoch;
     ContentType content_type;
     opaque authenticated_data<0..2^32-1>;
-    opaque sender_data_nonce<0..255>;
-} MLSCiphertextSenderDataAAD;
+} MLSSenderDataAAD;
 ~~~~~
 
 When parsing a SenderData struct as part of message decryption, the


### PR DESCRIPTION
With any AEAD, the nonce is necessarily already authenticated. Also, the name of the struct was changed to be more clear.