### PR TITLE
Make ratcheting optional for Adds

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -139,6 +139,10 @@ shared keys with costs that scale as the log of the group size.
 
 RFC EDITOR PLEASE DELETE THIS SECTION.
 
+draft-10
+
+- Re-enable constant-time Add (\*)
+
 draft-09
 
 - Remove blanking of nodes on Add (\*)

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2060,9 +2060,10 @@ message at the same time, by taking the following steps:
 * For each new member in the group:
   * Identify the lowest common ancestor in the tree of the new member's
     leaf node and the member sending the Commit
-  * Compute the path secret corresponding to the common ancestor node
+  * If the `path` field was populated above: Compute the path secret
+    corresponding to the common ancestor node
   * Compute an EncryptedGroupSecrets object that encapsulates the `init_secret`
-    for the current epoch and the path secret for the common ancestor.
+    for the current epoch and the path secret (if present).
 
 * Construct a Welcome message from the encrypted GroupInfo object and the
   encrypted group secrets.
@@ -2167,8 +2168,12 @@ struct {
 } GroupInfo;
 
 struct {
-  opaque epoch_secret<1..255>;
   opaque path_secret<1..255>;
+} PathSecret;
+
+struct {
+  opaque epoch_secret<1..255>;
+  optional<PathSecret> path_secret;
 } GroupSecrets;
 
 struct {
@@ -2238,9 +2243,10 @@ welcome_key = HKDF-Expand(welcome_secret, "key", key_length)
     * Update the leaf at index `index` with the private key corresponding to the
       public key in the node.
 
-    * Identify the lowest common ancestor of the leaves at `index` and at
+    * If the `path_secret` value is set in the GroupSecrets object: Identify the
+      lowest common ancestor of the leaves at `index` and at
       `GroupInfo.signer_index`.  Set the private key for this node to the
-      private key derived from the `path_secret` in the GroupSecrets object.
+      private key derived from the `path_secret`.
 
     * For each parent of the common ancestor, up to the root of the tree, derive
       a new path secret and set the private key for the node to the private key

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2038,6 +2038,10 @@ message at the same time, by taking the following steps:
   applied at the leftmost unoccupied leaf, or appended to the right edge of the
   tree if all leaves are occupied.
 
+* Decide whether to populate the `path` field: If the `path` field is required
+  based on the proposals that are in the commit (see above), then it MUST be
+  populated.  Otherwise, the sender MAY omit the `path` field at its discretion.
+
 * If populating the `path` field: Create a DirectPath using the new tree (which
   includes any new members).  The GroupContext for this operation uses the
   `group_id`, `epoch`, `tree_hash`, and `confirmed_transcript_hash` values in
@@ -2101,7 +2105,8 @@ A member of the group applies a Commit message by taking the following steps:
 
 * Verify that the `path` value is populated if either of the `updates` or
   `removes` vectors has length greater than zero, or if all of the `updates`,
-  `removes`, and `adds` vectors are empty.
+  `removes`, and `adds` vectors are empty.  Otherwise, the `path` value MAY be
+  omitted.
 
 * If the `path` value is populated: Process the `path` value using the ratchet
   tree the provisional GroupContext, to update the ratchet tree and generate the

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2007,7 +2007,19 @@ least one Update or Remove proposal, i.e., if the length of the `updates` or
 `removes vectors is greater than zero.  The `path` field MUST also be populated
 if the Commit covers no proposals at all (i.e., if all three proposal vectors
 are empty).  The `path` field MAY be omitted if the Commit covers only Add
-proposals.
+proposals.  In pseudocode, the logic for whether the `path` field is required is
+as follows:
+
+~~~~~
+haveUpdates = len(commit.Updates) > 0
+haveRemoves = len(commit.Removes) > 0
+haveAdds = len(commit.Adds) > 0
+
+haveUpdateOrRemove = haveUpdates || haveRemoves
+haveNoProposalsAtAll = !haveUpdateOrRemove && !haveAdds
+
+pathRequired = haveUpdateOrRemove || haveNoProposalsAtAll
+~~~~~
 
 A member of the group creates a Commit message and the corresponding Welcome
 message at the same time, by taking the following steps:


### PR DESCRIPTION
When we converted to the Proposal/Commit scheme, one of the consequences was that Adds became O(N) instead of O(1), since they had to Committed and commits encrypt the committer's direct path to the remainder of the tree.  This is ~log(N) in the nice case and ~N in the worst case.  At the time, we noted that one could special-case Add-only Commits in the future and make the update to the direct path optional in that case.

This PR implements that suggestion.  The leaf KeyPackage for the Commit is moved into the DirectPath struct, and the whole DirectPath is made optional.  The optional value MUST be provided for:

* A Commit committing an update or remove
* A "just update my path" Commit covering no proposals