### PR TITLE
Rely More on HPKE

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -720,9 +720,9 @@ node, from which the node's key pair is derived.
 
 ~~~~~
 path_secret[0] = HKDF-Expand-Label(leaf_hpke_secret,
-                                   "path", "", Nsk)
+                                   "path", "", KEM.Nsk)
 path_secret[n] = HKDF-Expand-Label(path_secret[n-1],
-                                   "path", "", Nsk)
+                                   "path", "", KEM.Nsk)
 node_priv[n], node_pub[n] = Derive-Key-Pair(path_secret[n])
 ~~~~~
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -720,9 +720,9 @@ node, from which the node's key pair is derived.
 
 ~~~~~
 path_secret[0] = HKDF-Expand-Label(leaf_hpke_secret,
-                                   "path", "", Hash.Length)
+                                   "path", "", Nsk)
 path_secret[n] = HKDF-Expand-Label(path_secret[n-1],
-                                   "path", "", Hash.Length)
+                                   "path", "", Nsk)
 node_priv[n], node_pub[n] = Derive-Key-Pair(path_secret[n])
 ~~~~~
 
@@ -844,8 +844,9 @@ following primitives to be used in group key computations:
 
 The ciphersuite's KEM used to instantiate an HPKE
 {{!I-D.irtf-cfrg-hpke}} instance for the purpose of public-key encryption.
-The ciphersuite must specify an algorithm `Derive-Key-Pair` that maps octet
-strings with length Hash.length to HPKE key pairs.
+Each ciphersuite has a `Derive-Key-Pair` function that maps octet strings of
+length `Nsk` (a KEM-specific constant defined by HPKE) to HPKE key pairs. This
+function is defined to be HPKE's `DeriveKeyPair` function.
 
 Ciphersuites are represented with the CipherSuite type. HPKE public keys
 are opaque values in a format defined by the underlying
@@ -861,31 +862,6 @@ to be used for signatures in MLSPlaintext and the tree signatures.  It MUST be
 the same as the signature algorithm specified in the credential field of the
 KeyPackage objects in the leaves of the tree (including the InitKeys
 used to add new members).
-
-For all ciphersuites defined in this document, the `Derive-Key-Pair` function
-rejection-samples candidate private key byte sequences until the `UnmarshalSk`
-function defined in HPKE {{!I-D.irtf-cfrg-hpke}} succeeds. Concretely,
-`Derive-Key-Pair(Secret)` will derive candidate octet strings of length `Nsk`
-(a KEM-specific constant defined in HPKE) as below
-
-~~~~~
-        "derive key pair"
-              |
-              V
-Secret -> HKDF-Extract
-              |
-              +--> HKDF-Expand-Label(., "sk candidate 1.", "", Nsk)
-              |
-              +--> HKDF-Expand-Label(., "sk candidate 2.", "", Nsk)
-              |
-              .
-              .
-              .
-~~~~~
-
-For each candidate octet string `enc`, `Derive-Key-Pair` will call
-`UnmarshalSk(enc)`. The first non-error return value of `UnmarshalSk` is
-considered the return value of `Derive-Key-Pair`.
 
 The ciphersuites are defined in section {{mls-ciphersuites}}.
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -838,18 +838,18 @@ Each MLS session uses a single ciphersuite that specifies the
 following primitives to be used in group key computations:
 
 * A hash function
-* A Diffie-Hellman finite-field group or elliptic curve group
+* A key encapsulation mechanism (KEM)
 * An AEAD encryption algorithm {{!RFC5116}}
 * A signature algorithm
 
-The ciphersuite's Diffie-Hellman group is used to instantiate an HPKE
+The ciphersuite's KEM used to instantiate an HPKE
 {{!I-D.irtf-cfrg-hpke}} instance for the purpose of public-key encryption.
 The ciphersuite must specify an algorithm `Derive-Key-Pair` that maps octet
 strings with length Hash.length to HPKE key pairs.
 
 Ciphersuites are represented with the CipherSuite type. HPKE public keys
-are opaque values in a format defined by the underlying Diffie-Hellman
-protocol (see the Ciphersuites section of the HPKE specification for more
+are opaque values in a format defined by the underlying
+protocol (see the Cryptographic Dependencies section of the HPKE specification for more
 information).
 
 ~~~~~
@@ -864,7 +864,9 @@ used to add new members).
 
 The ciphersuites are defined in section {{mls-ciphersuites}}.
 
-Depending on the Diffie-Hellman group of the ciphersuite, different rules apply
+### KEMs
+
+Depending on the KEM of the ciphersuite, different rules apply
 to private key derivation and public key verification.   For all ciphersuites
 defined in this document, the Derive-Key-Pair function begins by deriving a "key
 pair secret" of appropriate length, then converting it to a private key in the


### PR DESCRIPTION
The first commit is editorial. I removed all the DH terminology I could find and replaced it with KEM terminology.

The second commit is related to https://github.com/cfrg/draft-irtf-cfrg-hpke/pull/79. It would massively reduce complexity of implementations if people were able to rely on HPKE to do all private key parsing, key validation, public key computation, etc. Currently, all the information in the deleted CFRG and NIST sections is either redundant (performed by HPKE) or outdated and performed correctly by HPKE (e.g., old P-256 DH secret representation). Instead of having all this duplicated, it would be easier to keep it in one place.

An issue with the new definition of `Derive-Key-Pair`: Repeatedly calling `HKDF-Expand-Label` can be computationally expensive. Each call requires computing the group hash (which, okay, it could be cached) and serializing a struct. It would be nice to do something that's cheaper but still ties context into the secret key generation.