### PR TITLE
Upper bound on group size in early phase too low

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1283,7 +1283,7 @@ struct {
 
 struct {
     HPKEPublicKey public_key;
-    HPKECiphertext encrypted_path_secret<0..2^16-1>;
+    HPKECiphertext encrypted_path_secret<0..2^32-1>;
 } DirectPathNode;
 
 struct {


### PR DESCRIPTION
The co-path might contain a high number of resolved nodes when the tree is still empty. The worst case is ~N which is why the limit should be the same as for sender ID.