### PR TITLE
Upper bound for Commit

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1978,9 +1978,9 @@ hash function from the group's ciphersuite.
 opaque ProposalID<0..255>;
 
 struct {
-    ProposalID updates<0..2^16-1>;
-    ProposalID removes<0..2^16-1>;
-    ProposalID adds<0..2^16-1>;
+    ProposalID updates<0..2^32-1>;
+    ProposalID removes<0..2^32-1>;
+    ProposalID adds<0..2^32-1>;
 
     optional<DirectPath> path;
 } Commit;


### PR DESCRIPTION
The upper bound for the number of Proposals of each type in a Commit is currently 2^16.

This makes it impossible to create groups with more than 2^16 members in one go and it also limits the number of UpdateProposals and RemoveProposals that can happen between two Commits to 2^16.