### PR TITLE
no need extra layer of optional in GroupInfo.tree

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2181,7 +2181,7 @@ Commit.
 struct {
   opaque group_id<0..255>;
   uint64 epoch;
-  optional<Node> tree<1..2^32-1>;
+  Node tree<1..2^32-1>;
   opaque confirmed_transcript_hash<0..255>;
   opaque interim_transcript_hash<0..255>;
   Extension extensions<0..2^16-1>;


### PR DESCRIPTION
since the Node is optional inside.