### PR TITLE
Explicitly specify which nodes are targeted

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1286,8 +1286,13 @@ struct {
 } HPKECiphertext;
 
 struct {
+    uint32 node_index;
+    HPKECiphertext encrypted_path_secret;
+} DirectPathEncryption;
+
+struct {
     HPKEPublicKey public_key;
-    HPKECiphertext encrypted_path_secret<0..2^32-1>;
+    DirectPathEncryption encryptions<0..2^32-1>;
 } DirectPathNode;
 
 struct {


### PR DESCRIPTION
Currently, processing a DirectPath requires that the recipient have a full view of the ratchet tree, so that it can compute the resolutions of copath nodes.  This PR changes the DirectPath structure to explicitly state which tree node a given encryption of a path secret is targeted to.  This is a prerequisit for making full knowledge of the tree optional, as in #344.