### PR TITLE
Reorder key schedule inputs

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1290,20 +1290,8 @@ proceeds as shown in the following diagram:
                         V
 GroupContext_[n] -> KDF.Extract = epoch_secret
                         |
-                        +--> Derive-Secret(., "sender data")
-                        |    = sender_data_secret
-                        |
-                        +--> Derive-Secret(., "handshake")
-                        |    = handshake_secret
-                        |
-                        +--> Derive-Secret(., "app")
-                        |    = application_secret
-                        |
-                        +--> Derive-Secret(., "exporter")
-                        |    = exporter_secret
-                        |
-                        +--> Derive-Secret(., "confirm")
-                        |    = confirmation_key
+                        +--> Derive-Secret(., <label>)
+                        |    = <secret>
                         |
                         V
                   Derive-Secret(., "init")
@@ -1311,6 +1299,16 @@ GroupContext_[n] -> KDF.Extract = epoch_secret
                         V
                   init_secret_[n]
 ~~~~~
+
+A number of secrets are derived from the epoch secret for different purposes:
+
+| Secret                | Label         |
+|:----------------------|:--------------|
+| `sender_data_secret`  | "sender data" |
+| `handshake_secret`    | "handshake"   |
+| `application_secret`  | "app"         |
+| `exporter_secret`     | "exporter"    |
+| `confirmation_key`    | "confirm"     |
 
 ## Pre-Shared Keys
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1279,7 +1279,13 @@ proceeds as shown in the following diagram:
                         |    = welcome_secret
                         |
                         V
+                  Derive-Secret(., "member")
+                        |
+                        V
       PSK (or 0) -> KDF.Extract = member_secret
+                        |
+                        V
+                  Derive-Secret(., "epoch")
                         |
                         V
 GroupContext_[n] -> KDF.Extract = epoch_secret

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1273,16 +1273,16 @@ proceeds as shown in the following diagram:
                   init_secret_[n-1] (or 0)
                         |
                         V
-   commit_secret -> HKDF-Extract = joiner_secret
+   commit_secret -> KDF.Extract = joiner_secret
                         |
                         +--> Derive-Secret(., "welcome")
                         |    = welcome_secret
                         |
                         V
-      PSK (or 0) -> HKDF-Extract = member_secret
+      PSK (or 0) -> KDF.Extract = member_secret
                         |
                         V
-GroupContext_[n] -> HKDF-Extract = epoch_secret
+GroupContext_[n] -> KDF.Extract = epoch_secret
                         |
                         +--> Derive-Secret(., "sender data")
                         |    = sender_data_secret


### PR DESCRIPTION
This PR rearranges the key schedule so that the following values are all fed into the init secret to form epoch secret:

1. The commit secret
2. The PSK (if any)
3. The group context

This assures that new joiners know the PSK for the epoch, since they now need to know it to compute the epoch secret.  It also moves the group context from the `Derive-Secret` calls under the epoch secret to the derivation of the epoch secret itself, ensuring that everything derived in the epoch has the same context folded in.

Fixes #325 
Fixes #326 