### PR TITLE
Commit Generation Clarifications

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -698,13 +698,13 @@ they receive the private keys for nodes, as described in
 
 ## Ratchet Tree Evolution
 
-When performing a Commit, the leaf KeyPackage of the committer and
-its direct path to the root are updated with new secret values.  The
+When performing a Commit, the generator of the Commit updates its leaf
+KeyPackage and its direct path to the root with new secret values.  The
 HPKE leaf public key within the KeyPackage MUST be derived from a freshly
 generated HPKE secret key to provide post-compromise security.
 
 The generator of the Commit starts by using the freshly generated HPKE secret
-key "leaf_hpke_secret" associated with the updated leaf KeyPackage (see
+key "leaf_hpke_secret" associated with its now-updated leaf KeyPackage (see
 {{key-packages}}) to compute "path_secret\[0\]" and generate a
 sequence of "path secrets", one for each ancestor of its leaf.  That
 is, path_secret\[0\] is used for the node directly above the leaf,

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -700,11 +700,11 @@ they receive the private keys for nodes, as described in
 
 When performing a Commit, the leaf KeyPackage of the committer and
 its direct path to the root are updated with new secret values.  The
-HPKE leaf public key within the KeyPackage MUST be a freshly
-generated value to provide post-compromise security.
+HPKE leaf public key within the KeyPackage MUST be derived from a freshly
+generated HPKE secret key to provide post-compromise security.
 
-The generator of the Commit starts by using the HPKE secret key
-"leaf_hpke_secret" associated with the new leaf KeyPackage (see
+The generator of the Commit starts by using the freshly generated HPKE secret
+key "leaf_hpke_secret" associated with the updated leaf KeyPackage (see
 {{key-packages}}) to compute "path_secret\[0\]" and generate a
 sequence of "path secrets", one for each ancestor of its leaf.  That
 is, path_secret\[0\] is used for the node directly above the leaf,


### PR DESCRIPTION
This PR tries to clarify these paragraphs by the following: 

- Differentiating between HPKE public/private keys when describing how these keys are rotated for a commit
- Clarifying who does the actions associated with a commit
- Adding consistency fixes between the two paragraphs

Let me know if these fixes are not quite right, as this PR tries to clarify where I had questions when reading. 