### PR TITLE
Readability edits for section 'Synchronizing Views of the Tree'

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -825,7 +825,7 @@ values:
 | pk(ns\[1\])  | E(pk(C), ps\[1\]), E(pk(D), ps\[1\]) |
 | pk(ns\[0\])  | E(pk(A), ps\[0\])                    |
 
-In this table, the value pk(ns\[1\]) represents the public key
+In this table, the value pk(ns\[X\]) represents the public key
 derived from the node secret X, whereas pk(X) represents the public leaf key
 for user X.  The value E(K, S) represents
 the public-key encryption of the path secret S to the

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -828,6 +828,8 @@ derived from the node secret X.  The value E(K, S) represents
 the public-key encryption of the path secret S to the
 public key K.
 
+After applying the commit, all group members MUST delete outdated path secrets.
+
 
 # Cryptographic Objects
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -823,8 +823,9 @@ values:
 | pk(ns\[1\])  | E(pk(C), ps\[1\]), E(pk(D), ps\[1\]) |
 | pk(ns\[0\])  | E(pk(A), ps\[0\])                    |
 
-In this table, the value pk(X) represents the public key
-derived from the node secret X.  The value E(K, S) represents
+In this table, the value pk(ns\[1\]) represents the public key
+derived from the node secret X, whereas pk(X) represents the public leaf key
+for user X.  The value E(K, S) represents
 the public-key encryption of the path secret S to the
 public key K.
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -766,7 +766,9 @@ delete the leaf_secret.
 
 ## Synchronizing Views of the Tree
 
-The members of the group need to keep their views of the tree in
+After generating a Commit as described in the prior section, the generator of
+the Commit must broadcast this update to other members of the group, who will need to
+apply it to keep their views of the tree in
 sync and up to date.  When a client commits a change to the tree
 (e.g., to add or remove a member), it transmits a handshake message
 containing a set of public

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -835,7 +835,7 @@ After processing the update, each recipient MUST delete outdated key material,
 specifically:
 
 * The path secrets used to derive each updated node key pair.
-* Each outdated key pair that was replaced by the update.
+* Each outdated node key pair that was replaced by the update.
 
 
 # Cryptographic Objects

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -767,9 +767,9 @@ delete the leaf_secret.
 ## Synchronizing Views of the Tree
 
 After generating a Commit as described in the prior section, the generator of
-the Commit must broadcast this update to other members of the group, who will need to
-apply it to keep their views of the tree in
-sync and up to date.  When a client commits a change to the tree
+the Commit must broadcast this update to other members of the group, who
+apply it to keep their local views of the tree in
+sync with the sender's.  When a client commits a change to the tree
 (e.g., to add or remove a member), it transmits a handshake message
 containing a set of public
 values for intermediate nodes in the direct path of a leaf. The

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -831,7 +831,11 @@ for user X.  The value E(K, S) represents
 the public-key encryption of the path secret S to the
 public key K.
 
-After applying the commit, all group members MUST delete outdated path secrets.
+After processing the update, each recipient MUST delete outdated key material,
+specifically:
+
+* The path secrets used to derive each updated node key pair.
+* Each outdated key pair that was replaced by the update.
 
 
 # Cryptographic Objects


### PR DESCRIPTION
This PR does the following: 

- Adds a lead-in sentence describing how this section builds on the prior. 
- Differentiates between public keys for nodes and public keys for leaves (users)
- Clarifies when secret key material needs to be deleted. 

I also wanted to make a couple other changes, but wanted feedback first. 

1. This section describes the private value corresponding to a node's public key as 'ns[0]' (or node secret), whereas the prior section referred to it as 'np[0]' (or node_priv). It would be better to have these terms be consistent.
2.  On line 773, it says that the client "...transmits a handshake message containing a set of **public** values" and on line 776 it says that "other members of the group can use these **public** values to update". However, this values seems to be contradictory with the value listed on line 785. 
3. The current terminology is unclear regarding 1) a Commit to the tree, 2) an update to the tree, and and 3) a handshake message. I think these are very similar but using the same language consistently would be better (such as defining a Commit as what updates the tree, and then describing how the handshake message is different from a Commit message, which is described earlier in the spec). 