### PR TITLE
4 editorial edits to the draft

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1947,7 +1947,7 @@ operation, where only the leaf changes and intermediate nodes are blanked out.
 
 The `path` field of a Commit message MUST be populated if the Commit covers at
 least one Update or Remove proposal, i.e., if the length of the `updates` or
-`removes vectors is greater than zero.  The `path` field MUST also be populated
+`removes` vectors is greater than zero.  The `path` field MUST also be populated
 if the Commit covers no proposals at all (i.e., if all three proposal vectors
 are empty).  The `path` field MAY be omitted if the Commit covers only Add
 proposals.  In pseudocode, the logic for whether the `path` field is required is

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1875,7 +1875,7 @@ originating outside the group are identified by a `preconfigured` or
 
 The `new_member` SenderType is used for clients proposing that they themselves
 be added.  For this ID type the sender value MUST be zero and the Proposal type
-must be Add. The MLSPlaintext MUST be signed with the private key corresponding
+MUST be Add. The MLSPlaintext MUST be signed with the private key corresponding
 to the KeyPackage in the Add message.  Recipients MUST verify that the
 MLSPlaintext carrying the Proposal message is validly signed with this key.
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2358,7 +2358,6 @@ indicated by the `epoch` field of the enclosing MLSPlaintext
 message. If the changes implied by a Commit messages are made
 starting from a different state, the results will be incorrect.
 
-
 This need for sequencing is not a problem as long as each time a
 group member sends a Commit message, it is based on the most
 current state of the group.  In practice, however, there is a risk


### PR DESCRIPTION
A couple of minor editorial changes to the current draft, namely:

<details>
<summary>There was a missing grave accent in one of the paragraphs of <a href="https://github.com/mlswg/mls-protocol/blob/c3db39266505e9d202158d642d65918d35870e77/draft-ietf-mls-protocol.md#commit">the Commit section</a> causing some formatting issues</summary>

**Before**:

![paragraph before](https://user-images.githubusercontent.com/3742559/89263277-9fc21c80-d639-11ea-9bd1-19e377fa3628.png)

**After**:

![paragraph after](https://user-images.githubusercontent.com/3742559/89263328-b9fbfa80-d639-11ea-8d5d-3b1c27c7d884.png)

</details>

<details>
<summary>Fix typo Pre-Shared Keys section</summary>


[...], it does not necessarily provide the same [...] guarantees ~than~ as a Commit message.

</details>


<details>
<summary>Resolve remaining reference to <code>prior_epoch</code></summary>

In the Sequencing section there was a reference to a `prior_epoch` field that was introduced in 2fa6ed3c6afc7d308905255b4cabe154a48d1e4b. However, in 69e12cd61378aae4a81199c28a16e2802666b6e3, it was removed from the struct where it was added. That entire struct was then removed in 27c9c28f9634a06a9b7921ea9c15e276f8c9ff6f, after which the trail runs cold. So I wasn't able to figure out exactly what it must be based on what on what it originally was. Hence, I replaced it with something that makes sense in context.

I based the new text on the following line found in the <a href="https://github.com/mlswg/mls-protocol/blob/39455d2ea5e8fb42e8f0f0624bddd8c56675da0e/draft-ietf-mls-protocol.md#commit">(current) Commit section</a>:

> Verify that the `epoch` field of the enclosing MLSPlaintext message is
> equal to the `epoch` field of the current GroupContext object

</details>


<details>
<summary>Rewrite paragraph on the <code>new_member</code> SenderType</summary>

I found the phrase " In such cases" after the sentence "Proposals with types other than Add MUST NOT be sent with this sender type" slightly confusing and awkward. To improve this I rewrote the paragraph.

</details>