### PR TITLE
Require the initial init_secret to be a random value

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1271,7 +1271,7 @@ the below diagram:
 When processing a handshake message, a client combines the
 following information to derive new epoch secrets:
 
-* The init secret from the previous epoch.
+* The init secret from the previous epoch
 * The commit secret for the current epoch
 * The GroupContext object for current epoch
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1714,7 +1714,7 @@ The creator of a group MUST take the following steps to initialize the group:
   * Tree hash: The root hash of the above ratchet tree
   * Confirmed transcript hash: 0
   * Interim transcript hash: 0
-  * Init secret: a fresh random value
+  * Init secret: a fresh random value of size `KDF.Nh`
 
 * For each member, construct an Add proposal from the KeyPackage for that
   member (see {{add}})

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1271,8 +1271,7 @@ the below diagram:
 When processing a handshake message, a client combines the
 following information to derive new epoch secrets:
 
-* The init secret from the previous epoch. When the group is created and there
-  is no previous epoch a fresh random value MUST be used.
+* The init secret from the previous epoch.
 * The commit secret for the current epoch
 * The GroupContext object for current epoch
 
@@ -1715,7 +1714,7 @@ The creator of a group MUST take the following steps to initialize the group:
   * Tree hash: The root hash of the above ratchet tree
   * Confirmed transcript hash: 0
   * Interim transcript hash: 0
-  * Init secret: 0
+  * Init secret: a fresh random value
 
 * For each member, construct an Add proposal from the KeyPackage for that
   member (see {{add}})

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1271,7 +1271,8 @@ the below diagram:
 When processing a handshake message, a client combines the
 following information to derive new epoch secrets:
 
-* The init secret from the previous epoch
+* The init secret from the previous epoch. When the group is created and there
+  is no previous epoch a fresh random value MUST be used.
 * The commit secret for the current epoch
 * The GroupContext object for current epoch
 
@@ -1279,7 +1280,7 @@ Given these inputs, the derivation of secrets for an epoch
 proceeds as shown in the following diagram:
 
 ~~~~~
-                  init_secret_[n-1] (or 0)
+                  init_secret_[n-1]
                         |
                         V
    commit_secret -> KDF.Extract = joiner_secret


### PR DESCRIPTION
This suggestion is based on a discussion in the MLS mailing list [[1]](https://mailarchive.ietf.org/arch/msg/mls/qrpAoK7aNSzKxX4O60pOLvM3cp8). It prevents issues that currently arrise when the very first commit of a group is an "add-only" commit because both the `commit_secret` and `init_secret` would be **0**.

Let me know if the wording or anything else should be changed.

/cc @bifurcation

---

1. https://mailarchive.ietf.org/arch/msg/mls/qrpAoK7aNSzKxX4O60pOLvM3cp8