### PR TITLE
Remove requirement to verify the group creation process

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1739,7 +1739,7 @@ KeyPackage, the leaf secret from which the Commit is built, and the
 intermediate key pairs along the direct path to the root.
 
 A new member receiving a Welcome message can recognize group creation if the
-number of entries in the `members` array is equal to the number of leaves in the
+number of entries in the `secrets` array is equal to the number of leaves in the
 tree minus one.  A client receiving a Welcome message SHOULD verify whether it
 is a newly created group, and if so, SHOULD verify that the above process was
 followed by reconstructing the Add and Commit messages and verifying that the

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1738,14 +1738,6 @@ introduced.  The only choices the creator makes here are its own
 KeyPackage, the leaf secret from which the Commit is built, and the
 intermediate key pairs along the direct path to the root.
 
-A new member receiving a Welcome message can recognize group creation if the
-number of entries in the `secrets` array is equal to the number of leaves in the
-tree minus one.  A client receiving a Welcome message SHOULD verify whether it
-is a newly created group, and if so, SHOULD verify that the above process was
-followed by reconstructing the Add and Commit messages and verifying that the
-resulting transcript hashes and epoch secret match those found in the Welcome
-message.
-
 # Group Evolution
 
 Over the lifetime of a group, its membership can change, and existing members


### PR DESCRIPTION
Closes #390

As discussed on [the mailing list](https://mailarchive.ietf.org/arch/msg/mls/CbBEhH5A7OyoP6Mf5FFXgSU0r30/) this removes the paragraph in the Group Creation section specifying that joiners SHOULD verify group creation if it is detected. A recent change to group creation - namely a random initial `init_secret` - makes it impossible to verify group creation.
