### PR TITLE
Authenticate group membership in MLSPlaintext

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1651,7 +1651,7 @@ verifying the content signature.
 
 The following sections describe the encryption and signing processes in detail.
 
-## Content Signing
+## Content Authentication
 
 The `signature` field in an MLSPlaintext object authenticates the sender of the
 MLSPlaintext message.  The input to the signature is an MLSPlaintextTBS
@@ -1660,10 +1660,10 @@ context for the signature that associates to the group messages sent within the
 group.
 
 In cases where the sender is a member of the group, the context contains the
-GroupContext for the current epoch and a "membership token" that authenticates
+GroupContext for the current epoch and a "membership tag" that authenticates
 that the sender is a member of the group.  As a result, for messages sent within
-a group, the signature authenticates not only the member's individual identity,
-but also their membership in the group.
+a group, the signature authenticates the member's individual identity, and the
+membersip tag authenticates their membership in the group.
 
 ~~~~~
 struct {
@@ -1738,6 +1738,10 @@ struct {
     opaque padding<0..2^16-1>;
 } MLSCiphertextContent;
 ~~~~~
+
+Note that the `membership_tag` is not carried forward from MLSPlaintext to
+MLSCiphertext.  In the context of an MLSCiphertext, the AEAD authentication
+provides the function that the `membership_tag` provides for MLSPlaintext.
 
 The key and nonce used for the encryption of the message depend on the
 content type of the message.  The sender chooses the handshake key for a

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1595,6 +1595,10 @@ struct {
 } Sender;
 
 struct {
+    opaque mac_value<0..255>;
+} MAC;
+
+struct {
     opaque group_id<0..255>;
     uint64 epoch;
     Sender sender;
@@ -1614,7 +1618,7 @@ struct {
     }
 
     opaque signature<0..2^16-1>;
-    opaque membership_tag<0..2^8-1>;
+    optional<MAC> membership_tag;
 } MLSPlaintext;
 
 struct {
@@ -1697,10 +1701,10 @@ struct {
 } MLSPlaintextTBM;
 ~~~~~
 
-The `membership_tag` field in the MLSPlaintext object authenticates the
-sender's membership in the group.  For an MLSPlaintext with a sender type other
-than `member`, this field MUST be set to the zero-length octet string.  For
-messages sent by members, it MUST be set to the following value:
+The `membership_tag` field in the MLSPlaintext object authenticates the sender's
+membership in the group.  For an MLSPlaintext with a sender type other than
+`member`, this field MUST be omitted.  For messages sent by members, it MUST be
+present and set to the following value:
 
 ~~~~~
 membership_tag = MAC(membership_key, MLSPlaintextTBM);


### PR DESCRIPTION
[Joël pointed out on the list](https://mailarchive.ietf.org/arch/msg/mls/LFz5nC4BnNTf7-OGIac5_QdlCRs/) that MLSPlaintext does not currently authenticate the sender's membership on the group, and as a result, some important attacks arise.  Discussion on the list indicated that adding a MAC with a key derived from the key schedule would provide this authentication.  This PR implements that suggestion.