### PR TITLE
Use UpdatePath instead of Commit when describing tree updates

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -701,9 +701,11 @@ they receive the private keys for nodes, as described in
 
 ## Ratchet Tree Evolution
 
-We now describe how members ratchet forward their group's shared secret with
-fresh key material. To do so, one member of the group will generate fresh key
-material, apply it to their local tree state, and then send this key material
+A member of a MLS group advances the key schedule to provide forward secrecy
+and post-compromise security by providing the group with fresh key material to
+be added into the group's shared secret.
+To do so, one member of the group generates fresh key
+material, applies it to their local tree state, and then sends this key material
 to other members in the group via an UpdatePath message (see {{update-paths}}) .
 All other group members then apply the key material in the UpdatePath to their
 own local tree state to derive the group's now-updated shared secret.
@@ -783,7 +785,7 @@ delete the leaf_secret.
 
 After generating fresh key material and applying it to ratchet forward their
 local tree state as described in the prior section, the generator must broadcast
-this update to other members of the group via an UpdatePath message, who
+this update to other members of the group in a Commit message, who
 apply it to keep their local views of the tree in
 sync with the sender's.  More specifically, when a member commits a change to
 the tree (e.g., to add or remove a member), it transmits a UpdatePath message

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1214,7 +1214,7 @@ is set to the zero-length octet string.
 
 ## Update Paths
 
-As described in {{commit}}, each MLS Commit message needs to
+As described in {{commit}}, each MLS Commit message may optionally
 transmit a KeyPackage leaf and node values along its direct path.
 The path contains a public key and encrypted secret value for all
 intermediate nodes in the path above the leaf.  The path is ordered

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -701,7 +701,7 @@ they receive the private keys for nodes, as described in
 
 ## Ratchet Tree Evolution
 
-A member of a MLS group advances the key schedule to provide forward secrecy
+A member of an MLS group advances the key schedule to provide forward secrecy
 and post-compromise security by providing the group with fresh key material to
 be added into the group's shared secret.
 To do so, one member of the group generates fresh key


### PR DESCRIPTION
This PR updates two sections to reference generating and sending an `UpdatePath` message, as not all Commits transmit fresh key material (as discussed in #391). 

This PR also includes light editorial edits for clarity and adds detail around the steps to perform an update.

Section 7.7 `Update Paths` currently says that "each MLS Commit message needs to transmit a KeyPackage leaf and node values along its direct path", but section 10.2 `Commit` says that an UpdatePath is optional. I can update 7.7 as well, if 10.2 is correct.