### PR TITLE
Allow for credentials supporting multiple signature schemes

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -889,26 +889,33 @@ The ciphersuites are defined in section {{mls-ciphersuites}}.
 
 ## Credentials
 
-A member of a group authenticates the identities of other
-participants by means of credentials issued by some authentication
-system, like a PKI.  Each type of credential MUST express the
-following data:
+A member of a group authenticates the identities of other participants by means
+of credentials issued by some authentication system, like a PKI. Each type of
+credential MUST express the following data in the context of the group it is
+used with:
 
-* The public keys of one or more signature key pairs
+* The public key of a signature key pair matching the SignatureScheme specified
+  by the CipherSuite of the group
 * The identity of the holder of the private keys
-* The signature schemes corresponding to the individual key pairs (only if more
-  than one key pair is included)
 
 Credentials MAY also include information that allows a relying party
 to verify the identity / signing key binding.
 
+Additionally, Credentials SHOULD specify the signature scheme corresponding to
+each contained public key.
+
 ~~~~~
+
+// See IANA registry for registered values
+uint16 SignatureScheme;
+
 // See IANA registry for registered values
 uint16 CredentialType;
 
 struct {
     opaque identity<0..2^16-1>;
     opaque identity_key<0..2^16-1>;
+    SignatureScheme signature_scheme;
 } BasicCredential;
 
 struct {

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -905,7 +905,6 @@ Additionally, Credentials SHOULD specify the signature scheme corresponding to
 each contained public key.
 
 ~~~~~
-
 // See IANA registry for registered values
 uint16 SignatureScheme;
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -894,9 +894,10 @@ participants by means of credentials issued by some authentication
 system, like a PKI.  Each type of credential MUST express the
 following data:
 
-* The public key of a signature key pair
-* The identity of the holder of the private key
-* The signature scheme that the holder will use to sign MLS messages
+* The public keys of one or more signature key pairs
+* The identity of the holder of the private keys
+* The signature schemes corresponding to the individual key pairs (only if more
+  than one key pair is included)
 
 Credentials MAY also include information that allows a relying party
 to verify the identity / signing key binding.
@@ -907,7 +908,7 @@ uint16 CredentialType;
 
 struct {
     opaque identity<0..2^16-1>;
-    opaque public_key<0..2^16-1>;
+    opaque identity_key<0..2^16-1>;
 } BasicCredential;
 
 struct {
@@ -946,10 +947,16 @@ member can use to add this client to the group asynchronously.
 
 A KeyPackage object specifies a ciphersuite that the client
 supports, as well as providing a public key that others can use
-for key agreement. The client's identity key can be updated
-throughout the lifetime of the group by sending a new KeyPackage
-with a new identity; the new identity MUST be validated by the
-authentication service.
+for key agreement.
+
+If the credential present in the KeyPackage supports multiple signature schemes,
+it MUST support the one indicated by the ciphersuite of the KeyPackage. The
+public key corresponding to that signature scheme MUST be used to authenticate
+the group member represented by the KeyPackage.
+
+The client's identity key can be updated throughout the lifetime of the group by
+sending a new KeyPackage with a new identity key; the new identity key MUST be
+validated by the authentication service.
 
 When used as InitKeys, KeyPackages are intended to be used only once and SHOULD NOT
 be reused except in case of last resort. (See {{initkey-reuse}}).

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -914,8 +914,8 @@ uint16 CredentialType;
 
 struct {
     opaque identity<0..2^16-1>;
-    opaque signature_key<0..2^16-1>;
     SignatureScheme signature_scheme;
+    opaque signature_key<0..2^16-1>;
 } BasicCredential;
 
 struct {


### PR DESCRIPTION
The credentials we have defined at the moment only contain a single public key and no information regarding what signature scheme that keypair works with (even though the Spec actually says it should include the signature scheme as well).

It would be nice, however, to support potential CredentialTypes that, similar to KeyPackages, include multiple supported signature schemes, each accompanied by a corresponding public key.

The Key that should be used in any given group is then determined by the CipherSuite of the group (which includes a Signature Scheme). When choosing a KeyPackage of a new member, it has to be one that contains a Credential which supports that Signature Scheme.

Note, that I'm not suggesting that this be the case in all Credentials, or even that we change the BasicCredential.

I understand that it's possible to have multiple credentials per identity, but in some authentication settings it can be beneficial to have a 1-to-1 mapping between Credential and identity.