### PR TITLE
Remove long term and explicitly prevent changing of identity

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -943,12 +943,12 @@ provide some public information about a user. KeyPackage
 structures provide information about a client that any existing
 member can use to add this client to the group asynchronously.
 
-A KeyPackage object specifies a ciphersuite that the client
-supports, as well as providing a public key that others can use
-for key agreement. The client's identity key can be updated
-throughout the lifetime of the group by sending a new KeyPackage
-with a new identity; the new identity MUST be validated by the
-authentication service.
+A KeyPackage object specifies a ciphersuite that the client supports, as well as
+providing a public key that others can use for key agreement. The client's
+identity key can be updated throughout the lifetime of the group by sending a
+new KeyPackage with a new Credential. However, the identity MUST be the same in
+both Credentials and the new Credential MUST be validated by the authentication
+service.
 
 When used as InitKeys, KeyPackages are intended to be used only once and SHOULD NOT
 be reused except in case of last resort. (See {{initkey-reuse}}).

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -312,10 +312,8 @@ Initialization Key (InitKey):
 : A key package that is prepublished by a client, which other clients can use to
   introduce the client to a new group.
 
-
 Signature Key:
 : A signing key pair used to authenticate the sender of a message.
-
 
 Terminology specific to tree computations is described in
 {{ratchet-trees}}.
@@ -329,7 +327,6 @@ describe the structure of protocol messages.
 This protocol is designed to execute in the context of a Service Provider (SP)
 as described in {{?I-D.ietf-mls-architecture}}.  In particular, we assume
 the SP provides the following services:
-
 
 * A signature key provider which allows clients to authenticate
   protocol messages in a group.
@@ -951,7 +948,7 @@ supports, as well as providing a public key that others can use
 for key agreement. The client's signature key can be updated
 throughout the lifetime of the group by sending a new KeyPackage
 with a new Credential. However, the identity MUST be the same in
-both Credentials and the new Credential MUST be validated by the 
+both Credentials and the new Credential MUST be validated by the
 authentication service.
 
 When used as InitKeys, KeyPackages are intended to be used only once and SHOULD NOT
@@ -2679,7 +2676,6 @@ tree is secret and thus so are all values derived from it.
 Initial leaf keys are known only by their owner and the group creator,
 because they are derived from an authenticated key exchange protocol.
 Subsequent leaf keys are known only by their owner.
-
 
 Note that the signature keys used by the protocol MUST be
 distributed by an "honest" authentication service for clients to

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -328,7 +328,7 @@ This protocol is designed to execute in the context of a Service Provider (SP)
 as described in {{?I-D.ietf-mls-architecture}}.  In particular, we assume
 the SP provides the following services:
 
-* A identity key provider which allows clients to authenticate
+* An identity key provider which allows clients to authenticate
   protocol messages in a group.
 
 * A broadcast channel, for each group, which will relay a message to all members

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -313,8 +313,7 @@ Initialization Key (InitKey):
   introduce the client to a new group.
 
 Identity Key:
-: A long-lived signing key pair used to authenticate the sender of a
-  message.
+: A signing key pair used to authenticate the sender of a message.
 
 Terminology specific to tree computations is described in
 {{ratchet-trees}}.
@@ -329,7 +328,7 @@ This protocol is designed to execute in the context of a Service Provider (SP)
 as described in {{?I-D.ietf-mls-architecture}}.  In particular, we assume
 the SP provides the following services:
 
-* A long-term identity key provider which allows clients to authenticate
+* A identity key provider which allows clients to authenticate
   protocol messages in a group.
 
 * A broadcast channel, for each group, which will relay a message to all members
@@ -2677,7 +2676,7 @@ Initial leaf keys are known only by their owner and the group creator,
 because they are derived from an authenticated key exchange protocol.
 Subsequent leaf keys are known only by their owner.
 
-Note that the long-term identity keys used by the protocol MUST be
+Note that the identity keys used by the protocol MUST be
 distributed by an "honest" authentication service for clients to
 authenticate their legitimate peers.
 


### PR DESCRIPTION
Rotating keys is important and in some cases, Signature Keys are not going to be very "long-term". Instead they're going to be rotated periodically.

I thus propose we simply remove the assumption that Signature Keys are of a "long-term" nature (or otherwise "long-lived"). 

The second change in this PR is that I added a few words indicating explicitly that the identity must not change when updating a KeyPackage.