### PR TITLE
Allow proposals by value in Commit

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2083,7 +2083,7 @@ struct {
 On receiving an MLSPlaintext containing a Proposal, a client MUST verify the
 signature on the enclosing MLSPlaintext.  If the signature verifies
 successfully, then the Proposal should be cached in such a way that it can be
-retrieved using a ProposalID in a later Commit message.
+retrieved using by hash (as a ProposalOrRef object) in a later Commit message.
 
 ### Add
 
@@ -2228,7 +2228,7 @@ A Commit message initiates a new epoch for the group, based on a collection of
 Proposals. It instructs group members to update their representation of the
 state of the group by applying the proposals and advancing the key schedule.
 
-Each proposal covered by the Commit is identified by a ProposalID value, which
+Each proposal covered by the Commit is included by a ProposalOrRef value, which
 identifies the proposal to be applied by value or by reference.  Proposals
 supplied by value are included directly in the Commit object.  Proposals
 supplied by reference are specified by including the hash of the MLSPlaintext in

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2233,10 +2233,9 @@ identifies the proposal to be applied by value or by reference.  Proposals
 supplied by value are included directly in the Commit object.  Proposals
 supplied by reference are specified by including the hash of the MLSPlaintext in
 which the Proposal was sent, using the hash function from the group's
-ciphersuite.  For proposals whose application depends on who sent them (e.g.,
-Update), the sender of the proposal is the same as the sender of the Commit.
-Conversely, proposals sent by people other than the committer MUST be included
-by reference.
+ciphersuite.  For proposals supplied by value, the sender of the proposal is the
+same as the sender of the Commit.  Conversely, proposals sent by people other
+than the committer MUST be included by reference.
 
 ~~~~~
 enum {

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2233,26 +2233,29 @@ identifies the proposal to be applied by value or by reference.  Proposals
 supplied by value are included directly in the Commit object.  Proposals
 supplied by reference are specified by including the hash of the MLSPlaintext in
 which the Proposal was sent, using the hash function from the group's
-ciphersuite.
+ciphersuite.  For proposals whose application depends on who sent them (e.g.,
+Update), the sender of the proposal is the same as the sender of the Commit.
+Conversely, proposals sent by people other than the committer MUST be included
+by reference.
 
 ~~~~~
 enum {
   reserved(0),
-  value(1)
-  plaintext_hash(2),
+  proposal(1)
+  reference(2),
   (255)
-} ProposalIDType;
+} ProposalOrRefType;
 
 struct {
-  ProposalIDType type;
-  select (ProposalID.type) {
-    case value:          Proposal proposal;
-    case plaintext_hash: opaque hash<0..255>;
+  ProposalOrRefType type;
+  select (ProposalOrRef.type) {
+    case 0: Proposal proposal;
+    case 1: opaque hash<0..255>;
   }
-} ProposalID;
+} ProposalOrRef;
 
 struct {
-    ProposalID proposals<0..2^32-1>;
+    ProposalOrRef proposals<0..2^32-1>;
     optional<UpdatePath> path;
 } Commit;
 ~~~~~

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2083,7 +2083,7 @@ struct {
 On receiving an MLSPlaintext containing a Proposal, a client MUST verify the
 signature on the enclosing MLSPlaintext.  If the signature verifies
 successfully, then the Proposal should be cached in such a way that it can be
-retrieved using by hash (as a ProposalOrRef object) in a later Commit message.
+retrieved by hash (as a ProposalOrRef object) in a later Commit message.
 
 ### Add
 
@@ -2248,8 +2248,8 @@ enum {
 struct {
   ProposalOrRefType type;
   select (ProposalOrRef.type) {
-    case 0: Proposal proposal;
-    case 1: opaque hash<0..255>;
+    case proposal:  Proposal proposal;
+    case reference: opaque hash<0..255>;
   }
 } ProposalOrRef;
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2245,7 +2245,7 @@ enum {
 
 struct {
   ProposalIDType type;
-  select (type) {
+  select (ProposalID.type) {
     case value:          Proposal proposal;
     case plaintext_hash: opaque hash<0..255>;
   }

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2229,11 +2229,27 @@ Proposals. It instructs group members to update their representation of the
 state of the group by applying the proposals and advancing the key schedule.
 
 Each proposal covered by the Commit is identified by a ProposalID value, which
-contains the hash of the MLSPlaintext in which the Proposal was sent, using the
-hash function from the group's ciphersuite.
+identifies the proposal to be applied by value or by reference.  Proposals
+supplied by value are included directly in the Commit object.  Proposals
+supplied by reference are specified by including the hash of the MLSPlaintext in
+which the Proposal was sent, using the hash function from the group's
+ciphersuite.
 
 ~~~~~
-opaque ProposalID<0..255>;
+enum {
+  reserved(0),
+  value(1)
+  plaintext_hash(2),
+  (255)
+} ProposalIDType;
+
+struct {
+  ProposalIDType type;
+  select (type) {
+    case value:          Proposal proposal;
+    case plaintext_hash: opaque hash<0..255>;
+  }
+} ProposalID;
 
 struct {
     ProposalID proposals<0..2^32-1>;


### PR DESCRIPTION
This avoids extra signatures and message overhead in the case where the committer is originating proposals.