### PR TITLE
Inlclude the signature in the confirmation tag

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1220,10 +1220,11 @@ interim_transcript_hash_[n+1] =
 
 Thus the `confirmed_transcript_hash` field in a GroupContext object represents a
 transcript over the whole history of MLSPlaintext Commit messages, up to the
-confirmation tag field in the current MLSPlaintext message.  The confirmation tag
-is then included in the transcript for the next epoch.  The interim transcript hash
-is passed to new members in the GroupInfo struct, and enables existing members to
-incorporate a Commit message into the transcript without having to store the whole MLSPlaintextCommitAuthData structure.
+confirmation tag field in the current MLSPlaintext message.  The confirmation tag 
+is then included in the transcript for the next epoch.  The interim transcript 
+hash is passed to new members in the GroupInfo struct, and enables existing 
+members to incorporate a Commit message into the transcript without having to 
+store the whole MLSPlaintextCommitAuthData structure.
 
 As shown above, when a new group is created, the `interim_transcript_hash` field
 is set to the zero-length octet string.

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1204,7 +1204,7 @@ struct {
 } MLSPlaintextCommitContent;
 
 struct {
-    MAC confirmation_tag<0..255>;
+    MAC confirmation_tag;
 } MLSPlaintextCommitAuthData;
 
 interim_transcript_hash_[0] = ""; // zero-length octet string
@@ -1725,7 +1725,7 @@ struct {
     }
 
     opaque signature<0..2^16-1>;
-    optional<MAC> confirmation_tag<0..255>;
+    optional<MAC> confirmation_tag;
     optional<MAC> membership_tag;
 } MLSPlaintext;
 
@@ -1738,6 +1738,9 @@ struct {
     opaque ciphertext<0..2^32-1>;
 } MLSCiphertext;
 ~~~~~
+
+The field `confirmation_tag` MUST be present if `content_type` equals commit.
+Otherwise, it MUST NOT be present.
 
 External sender types are sent as MLSPlaintext, see {{external-proposals}}
 for their use.
@@ -1808,7 +1811,7 @@ present and set to the following value:
 struct {
   MLSPlaintextTBS tbs;
   opaque signature<0..2^16-1>;
-  optional<MAC> confirmation_tag<0..255>;
+  optional<MAC> confirmation_tag;
 } MLSPlaintextTBM;
 
 membership_tag = MAC(membership_key, MLSPlaintextTBM);
@@ -1839,7 +1842,7 @@ struct {
     }
 
     opaque signature<0..2^16-1>;
-    optional<MAC> confirmation_tag<0..255>;
+    optional<MAC> confirmation_tag;
     opaque padding<0..2^16-1>;
 } MLSCiphertextContent;
 ~~~~~
@@ -2526,7 +2529,7 @@ struct {
   opaque confirmed_transcript_hash<0..255>;
   opaque interim_transcript_hash<0..255>;
   Extension extensions<0..2^32-1>;
-  opaque confirmation_tag<0..255>;
+  MAC confirmation_tag;
   uint32 signer_index;
   opaque signature<0..2^16-1>;
 } GroupInfo;


### PR DESCRIPTION
As discussed in the mailing list, not having the signature contribute to the new epoch's key schedule leads to a one-off effect where parties stay in sync (with respect to keys) for one more epoch, before inevitably go out of sync. This pull request addresses this issue by including the signature in the confirmed transcript hash rather than the interim transcript hash. See the mailing list for a security consideration of this change.

Credit: This pull request was primarily authored by Marta Mularczk; I'm just posting it here for administrative reasons. 