### PR TITLE
Authentication Secret

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1345,6 +1345,7 @@ A number of secrets are derived from the epoch secret for different purposes:
 | `sender_data_secret`  | "sender data" |
 | `encryption_secret`   | "encryption"  |
 | `exporter_secret`     | "exporter"    |
+| `authentication_secret | "auth"  |
 | `confirmation_key`    | "confirm"     |
 | `membership_key`      | "membership"  |
 | `recovery_secret`       | "recovery"    |

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1540,11 +1540,11 @@ key material reuse.
 
 ## State Authentication Keys
 
-The main MLS key schedule provides a per-epoch `authentication_secret`. 
+The main MLS key schedule provides a per-epoch `authentication_secret`.
 If one of the parties is being actively impersonated by an attacker, their
 `authentication_secret` will differ from that of the other group members.
-Thus, members of a group MAY use their `authentication_secrets` within 
-an out-of-band authentication protocol to detect attacks or ensure that they 
+Thus, members of a group MAY use their `authentication_secrets` within
+an out-of-band authentication protocol to detect attacks or ensure that they
 share the same view of the group.
 
 # Message Framing
@@ -2311,10 +2311,10 @@ A member of the group applies a Commit message by taking the following steps:
 * Update the new GroupContext's confirmed and interim transcript hashes using the
   new Commit.
 
-* If the `proposals` vector contains any PreSharedKey proposals, derive the `psk_secret`
-  as specified in {{pre-shared-keys}}, where the order of PSKs in the derivation
-  corresponds to the order of PreSharedKey proposals in the `proposals` vector.
-  Otherwise, set `psk_secret` to 0.
+* If the `proposals` vector contains any PreSharedKey proposals, derive the
+  `psk_secret` as specified in {{pre-shared-keys}}, where the order of PSKs in
+  the derivation corresponds to the order of PreSharedKey proposals in the
+  `proposals` vector. Otherwise, set `psk_secret` to 0.
 
 * Use the `commit_secret`, the `psk_secret`, the provisional GroupContext, and
   the init secret from the previous epoch to compute the epoch secret and

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1346,8 +1346,8 @@ A number of secrets are derived from the epoch secret for different purposes:
 | `encryption_secret`    | "encryption"  |
 | `exporter_secret`      | "exporter"    |
 | `authentication_secret`| "auth"  |
-| `confirmation_key`    | "confirm"     |
-| `membership_key`        | "membership"  |
+| `confirmation_key`     | "confirm"     |
+| `membership_key`      | "membership"  |
 | `recovery_secret`      | "recovery"    |
 
 ## Pre-Shared Keys

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1347,7 +1347,7 @@ A number of secrets are derived from the epoch secret for different purposes:
 | `exporter_secret`      | "exporter"    |
 | `authentication_secret`| "auth"  |
 | `confirmation_key`     | "confirm"     |
-| `membership_key`        | "membership"  |
+| `membership_key`       | "membership"  |
 | `recovery_secret`      | "recovery"    |
 
 ## Pre-Shared Keys

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1340,15 +1340,15 @@ psk_secret (or 0) -> KDF.Extract = member_secret
 
 A number of secrets are derived from the epoch secret for different purposes:
 
-| Secret                | Label         |
-|:----------------------|:--------------|
+| Secret                           | Label         |
+|:-------------------------------|:--------------|
 | `sender_data_secret`   | "sender data" |
-| `encryption_secret`      | "encryption"  |
-| `exporter_secret`         | "exporter"    |
-| `authentication_secret | "auth"  |
-| `confirmation_key`       | "confirm"     |
-| `membership_key`       | "membership"  |
-| `recovery_secret`         | "recovery"    |
+| `encryption_secret`       | "encryption"  |
+| `exporter_secret`          | "exporter"    |
+| `authentication_secret` | "auth"  |
+| `confirmation_key`        | "confirm"     |
+| `membership_key`        | "membership"  |
+| `recovery_secret`          | "recovery"    |
 
 ## Pre-Shared Keys
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1340,12 +1340,12 @@ psk_secret (or 0) -> KDF.Extract = member_secret
 
 A number of secrets are derived from the epoch secret for different purposes:
 
-| Secret                      | Label         |
+| Secret                   | Label         |
 |:-----------------------|:--------------|
 | `sender_data_secret`   | "sender data" |
 | `encryption_secret`    | "encryption"  |
 | `exporter_secret`      | "exporter"    |
-| `authentication_secret`| "authentication"  |
+| `authentication_secret`| "authentication"|
 | `confirmation_key`     | "confirm"     |
 | `membership_key`       | "membership"  |
 | `recovery_secret`      | "recovery"    |

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1342,13 +1342,13 @@ A number of secrets are derived from the epoch secret for different purposes:
 
 | Secret                | Label         |
 |:----------------------|:--------------|
-| `sender_data_secret`  | "sender data" |
-| `encryption_secret`   | "encryption"  |
-| `exporter_secret`     | "exporter"    |
+| `sender_data_secret`   | "sender data" |
+| `encryption_secret`      | "encryption"  |
+| `exporter_secret`         | "exporter"    |
 | `authentication_secret | "auth"  |
-| `confirmation_key`    | "confirm"     |
-| `membership_key`      | "membership"  |
-| `recovery_secret`       | "recovery"    |
+| `confirmation_key`       | "confirm"     |
+| `membership_key`       | "membership"  |
+| `recovery_secret`         | "recovery"    |
 
 ## Pre-Shared Keys
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1341,14 +1341,14 @@ psk_secret (or 0) -> KDF.Extract = member_secret
 A number of secrets are derived from the epoch secret for different purposes:
 
 | Secret                           | Label         |
-|:-------------------------------|:--------------|
+|:-----------------------|:--------------|
 | `sender_data_secret`   | "sender data" |
 | `encryption_secret`    | "encryption"  |
 | `exporter_secret`      | "exporter"    |
-| `authentication_secret`  | "auth"  |
-| `confirmation_key`    | "confirm"     |
-| `membership_key`          | "membership"  |
-| `recovery_secret`       | "recovery"    |
+| `authentication_secret`| "auth"  |
+| `confirmation_key`      | "confirm"     |
+| `membership_key`      | "membership"  |
+| `recovery_secret`      | "recovery"    |
 
 ## Pre-Shared Keys
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1343,12 +1343,12 @@ A number of secrets are derived from the epoch secret for different purposes:
 | Secret                           | Label         |
 |:-------------------------------|:--------------|
 | `sender_data_secret`   | "sender data" |
-| `encryption_secret`       | "encryption"  |
-| `exporter_secret`          | "exporter"    |
-| `authentication_secret` | "auth"  |
-| `confirmation_key`        | "confirm"     |
-| `membership_key`        | "membership"  |
-| `recovery_secret`          | "recovery"    |
+| `encryption_secret`    | "encryption"  |
+| `exporter_secret`      | "exporter"    |
+| `authentication_secret`  | "auth"  |
+| `confirmation_key`    | "confirm"     |
+| `membership_key`          | "membership"  |
+| `recovery_secret`       | "recovery"    |
 
 ## Pre-Shared Keys
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1340,15 +1340,15 @@ psk_secret (or 0) -> KDF.Extract = member_secret
 
 A number of secrets are derived from the epoch secret for different purposes:
 
-| Secret                   | Label         |
+| Secret                 | Label         |
 |:-----------------------|:--------------|
-| `sender_data_secret`   | "sender data" |
-| `encryption_secret`    | "encryption"  |
-| `exporter_secret`      | "exporter"    |
+| `sender_data_secret`   | "sender data"   |
+| `encryption_secret`    | "encryption"    |
+| `exporter_secret`      | "exporter"      |
 | `authentication_secret`| "authentication"|
-| `confirmation_key`     | "confirm"     |
-| `membership_key`       | "membership"  |
-| `recovery_secret`      | "recovery"    |
+| `confirmation_key`     | "confirm"       |
+| `membership_key`       | "membership"    |
+| `recovery_secret`      | "recovery"      |
 
 ## Pre-Shared Keys
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1347,7 +1347,7 @@ A number of secrets are derived from the epoch secret for different purposes:
 | `exporter_secret`      | "exporter"    |
 | `authentication_secret`| "auth"  |
 | `confirmation_key`     | "confirm"     |
-| `membership_key`      | "membership"  |
+| `membership_key`        | "membership"  |
 | `recovery_secret`      | "recovery"    |
 
 ## Pre-Shared Keys

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1340,12 +1340,12 @@ psk_secret (or 0) -> KDF.Extract = member_secret
 
 A number of secrets are derived from the epoch secret for different purposes:
 
-| Secret                           | Label         |
+| Secret                      | Label         |
 |:-----------------------|:--------------|
 | `sender_data_secret`   | "sender data" |
 | `encryption_secret`    | "encryption"  |
 | `exporter_secret`      | "exporter"    |
-| `authentication_secret`| "auth"  |
+| `authentication_secret`| "authentication"  |
 | `confirmation_key`     | "confirm"     |
 | `membership_key`       | "membership"  |
 | `recovery_secret`      | "recovery"    |

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1346,8 +1346,8 @@ A number of secrets are derived from the epoch secret for different purposes:
 | `encryption_secret`    | "encryption"  |
 | `exporter_secret`      | "exporter"    |
 | `authentication_secret`| "auth"  |
-| `confirmation_key`      | "confirm"     |
-| `membership_key`      | "membership"  |
+| `confirmation_key`    | "confirm"     |
+| `membership_key`        | "membership"  |
 | `recovery_secret`      | "recovery"    |
 
 ## Pre-Shared Keys

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1340,8 +1340,8 @@ psk_secret (or 0) -> KDF.Extract = member_secret
 
 A number of secrets are derived from the epoch secret for different purposes:
 
-| Secret                 | Label         |
-|:-----------------------|:--------------|
+| Secret                 | Label           |
+|:-----------------------|:----------------|
 | `sender_data_secret`   | "sender data"   |
 | `encryption_secret`    | "encryption"    |
 | `exporter_secret`      | "exporter"      |


### PR DESCRIPTION
The authentication_secret was previously in a PR and agreed, but seems to have been removed from the key schedule (possibly during a merge). The discussion on its use is still present. This PR is just to add it back in to the key schedule.