### PR TITLE
No redundant ciphertexts

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2339,11 +2339,11 @@ message at the same time, by taking the following steps:
   based on the proposals that are in the commit (see above), then it MUST be
   populated.  Otherwise, the sender MAY omit the `path` field at its discretion.
 
-* If populating the `path` field: Create a UpdatePath using the new tree. While 
-  the new tree includes the new members, any new member (from an add proposal) 
-  MUST be exluded from the resolution during the computation of the UpdatePath. 
-  The GroupContext for this operation uses the `group_id`, `epoch`, `tree_hash`, 
-  and `confirmed_transcript_hash` values in the initial GroupContext object.
+* If populating the `path` field: Create a UpdatePath using the new tree. Any 
+  new member (from an add proposal) MUST be exluded from the resolution during 
+  the computation of the UpdatePath. The GroupContext for this operation uses 
+  the `group_id`, `epoch`, `tree_hash`, and `confirmed_transcript_hash` values 
+  in the initial GroupContext object.
 
    * Assign this UpdatePath to the `path` field in the Commit.
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1255,10 +1255,11 @@ struct {
 } UpdatePath;
 ~~~~~
 
-The number of ciphertexts in the `encrypted_path_secret` vector MUST
-be equal to the length of the resolution of the corresponding copath
-node.  Each ciphertext in the list is the encryption to the
-corresponding node in the resolution.
+For each `UpdatePathNode`, let `nodes_to_encrypt_for` be the the resolution of 
+the corresponding copath node excluding parties added as part of this MLS Commit
+message. The number of ciphertexts in the `encrypted_path_secret` vector MUST be
+equal to the length of `nodes_to_encrypt_for`. Each ciphertext in the list is the
+encryption to the corresponding node in `nodes_to_encrypt_for`.
 
 The HPKECiphertext values are computed as
 
@@ -2338,10 +2339,11 @@ message at the same time, by taking the following steps:
   based on the proposals that are in the commit (see above), then it MUST be
   populated.  Otherwise, the sender MAY omit the `path` field at its discretion.
 
-* If populating the `path` field: Create a UpdatePath using the new tree (which
-  includes any new members).  The GroupContext for this operation uses the
-  `group_id`, `epoch`, `tree_hash`, and `confirmed_transcript_hash` values in
-  the initial GroupContext object.
+* If populating the `path` field: Create a UpdatePath using the new tree. While 
+  the new tree includes the new members, any new member (from an add proposal) 
+  MUST be exluded from the resolution during the computation of the UpdatePath. 
+  The GroupContext for this operation uses the `group_id`, `epoch`, `tree_hash`, 
+  and `confirmed_transcript_hash` values in the initial GroupContext object.
 
    * Assign this UpdatePath to the `path` field in the Commit.
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1255,11 +1255,11 @@ struct {
 } UpdatePath;
 ~~~~~
 
-For each `UpdatePathNode`, let `nodes_to_encrypt_for` be the the resolution of 
-the corresponding copath node excluding parties added as part of this MLS Commit
+For each `UpdatePathNode`, the resolution of the corresponding copath node MUST
+be filtered by removing all new leaf nodes added as part of this MLS Commit
 message. The number of ciphertexts in the `encrypted_path_secret` vector MUST be
-equal to the length of `nodes_to_encrypt_for`. Each ciphertext in the list is the
-encryption to the corresponding node in `nodes_to_encrypt_for`.
+equal to the length of the filtered resolution, with each ciphertext being the 
+encryption to the respective resolution node.
 
 The HPKECiphertext values are computed as
 


### PR DESCRIPTION
As briefly explained in the mailing list, commit messages currently contain encryptions for newly added group members that never even receive this commit message. This PR explicitely exlcudes them during the preparation of the UpdatePath.