### PR TITLE
Remove interim transcript hash from GroupInfo

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1220,10 +1220,10 @@ interim_transcript_hash_[n+1] =
 
 Thus the `confirmed_transcript_hash` field in a GroupContext object represents a
 transcript over the whole history of MLSPlaintext Commit messages, up to the
-confirmation tag field in the current MLSPlaintext message.  The confirmation tag 
-is then included in the transcript for the next epoch.  The interim transcript 
-hash is passed to new members in the GroupInfo struct, and enables existing 
-members to incorporate a Commit message into the transcript without having to 
+confirmation tag field in the current MLSPlaintext message.  The confirmation tag
+is then included in the transcript for the next epoch.  The interim transcript
+hash is passed to new members in the GroupInfo struct, and enables existing
+members to incorporate a Commit message into the transcript without having to
 store the whole MLSPlaintextCommitAuthData structure.
 
 As shown above, when a new group is created, the `interim_transcript_hash` field
@@ -2369,7 +2369,7 @@ message at the same time, by taking the following steps:
 * Construct an MLSPlaintext object containing the Commit object. Sign the MLSPlaintext
   using the current epoch's GroupContext as context. Use the signature, the
   `commit_secret` and the `psk_secret` to advance the key schedule and compute
-  the `confirmation_tag` value in the MLSPlaintext. 
+  the `confirmation_tag` value in the MLSPlaintext.
 
 * Update the tree in the provisional state by applying the direct path
 
@@ -2528,7 +2528,6 @@ struct {
   uint64 epoch;
   opaque tree_hash<0..255>;
   opaque confirmed_transcript_hash<0..255>;
-  opaque interim_transcript_hash<0..255>;
   Extension extensions<0..2^32-1>;
   MAC confirmation_tag;
   uint32 signer_index;
@@ -2638,6 +2637,9 @@ welcome_key = KDF.Expand(welcome_secret, "key", key_length)
 
 * Verify the confirmation tag in the GroupInfo using the derived confirmation
   key and the `confirmed_transcript_hash` from the GroupInfo.
+
+* Use the confirmed transcript hash and confirmation tag to compute the interim
+  transcript hash in the new state.
 
 ## Ratchet Tree Extension
 


### PR DESCRIPTION
As discussed on 2020-10-20, this field is not needed now that #416 moved the signature under the confirmation tag.