### PR TITLE
move definition of ParentNode earlier

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1117,6 +1117,14 @@ message. If the extension is present, clients MUST verify that `parent_hash`
 matches the hash of the leaf's parent node when represented as a ParentNode
 struct.
 
+~~~~~
+struct {
+    HPKEPublicKey public_key;
+    uint32 unmerged_leaves<0..2^32-1>;
+    opaque parent_hash<0..255>;
+} ParentNode;
+~~~~~
+
 <!-- OPEN ISSUE: This scheme, in which the tree hash covers the parent hash, is
 designed to allow for more deniable deployments, since a signature by a member
 covers only its direct path. The other possible scheme, in which the parent hash
@@ -1148,12 +1156,6 @@ struct {
         case 1: T value;
     }
 } optional<T>;
-
-struct {
-    HPKEPublicKey public_key;
-    uint32 unmerged_leaves<0..2^32-1>;
-    opaque parent_hash<0..255>;
-} ParentNode;
 ~~~~~
 
 When computing the hash of a parent node, the `ParentNodeHashInput`


### PR DESCRIPTION
I think that this change will reduce the chance for [confusion](https://mailarchive.ietf.org/arch/msg/mls/UIWuwPC3ukryFUOANyH4cX4et3o/), as now the Parent Hash section will be self-contained, rather than needing to also look into the Tree Hashes section.  Also, it should hopefully be clearer that the `parent_hash` field in the `ParentNode` struct is calculated as the hash of another `ParentNode` struct, rather than the hash of a `ParentNodeHashInput`.

(Though I don't see anywhere that says what to use as `parent_hash` when the `ParentNode` refers to the root.)