### PR TITLE
Fix parent hash verification

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1114,8 +1114,15 @@ opaque parent_hash<0..255>;
 
 This extension MUST be present in all Updates that are sent as part of a Commit
 message. If the extension is present, clients MUST verify that `parent_hash`
-matches the hash of the leaf's parent node when represented as a ParentNode
+matches the hash of the leaf's parent node when represented as a ParentHashInput
 struct.
+
+~~~~~
+struct {
+    HPKEPublicKey public_key;
+    opaque parent_hash<0..255>;
+} ParentHashInput;
+~~~~~
 
 <!-- OPEN ISSUE: This scheme, in which the tree hash covers the parent hash, is
 designed to allow for more deniable deployments, since a signature by a member
@@ -1150,9 +1157,8 @@ struct {
 } optional<T>;
 
 struct {
-    HPKEPublicKey public_key;
+    ParentHashInput parent_hash_input;
     uint32 unmerged_leaves<0..2^32-1>;
-    opaque parent_hash<0..255>;
 } ParentNode;
 ~~~~~
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2752,7 +2752,9 @@ welcome_key = KDF.Expand(welcome_secret, "key", key_length)
     children are non-empty and have the hash of this node set as their
     `parent_hash` value (if the child is another parent) or has a `parent_hash`
     extension in the KeyPackage containing the same value (if the child is a
-    leaf).
+    leaf). If either of the node's children is empty, and in particular does not
+	have a parent hash, then its respective children's `parent_hash` values have
+	to be considered instead.
 
   * For each non-empty leaf node, verify the signature on the KeyPackage.
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2759,8 +2759,8 @@ welcome_key = KDF.Expand(welcome_secret, "key", key_length)
     `parent_hash` value (if the child is another parent) or has a `parent_hash`
     extension in the KeyPackage containing the same value (if the child is a
     leaf). If either of the node's children is empty, and in particular does not
-	have a parent hash, then its respective children's `parent_hash` values have
-	to be considered instead.
+    have a parent hash, then its respective children's `parent_hash` values have
+    to be considered instead.
 
   * For each non-empty leaf node, verify the signature on the KeyPackage.
 


### PR DESCRIPTION
This is a spin-off from the work on tree-signing by Joël, Marta, and me. Note that this obsoletes #434 as I couldn't figure out how to do dependent PRs in Github.

Consider the following ratchet tree and assume that (1) the left subtree is fully occupied and (2) E last committed in the right subtree, i.e., the key at node [A..F] has been sampled by E. 
```
       [root]   
           \
            \
             \
            [A..F]
            /    \
           /      \
          /        \
         /          \
     [A..D]        [EF]
      /  \          /\
     /    \        /  \
    /      \      /    \
  [AB]    [CD]   [E]   [F]
   /\      /\
  /  \    /  \
[A] [B] [C] [D]
```
Now say party Z from the left subtree committs a proposal that adds party G. According to my understanding the tree will look as follows, where I use the syntax [A..F,G] to denote that parties A to F know the secret key and G is tracked as an unmerged leaf. 
```
       [root]   
           \
            \
             \
           [A..F,G]
            /    \
           /      \
          /        \
         /          \
     [A..D]        [X]
      /  \          /\
     /    \        /  \
    /      \      /    \
  [AB]    [CD]   [EF]  [G]
   /\      /\     /\
  /  \    /  \   /  \
[A] [B] [C] [D] [E] [F]
```

Now observe the following two issues:
* According to the draft, G now has to verify that either of [A..F,G]'s children store a correct parent hash. However, its parent-hash is no longer stored in its direct child [X], an additional blank node inserted for the add, but still in [EF] instead. This needs to be accounted for in the verification.
* Orignally, the ``parent_hash`` includes ``unmerged_leaves``. Hence, for [A..F,G] the value stored in [EF] (and recursively signed by E) will no longer match the recomputed value. Since partent hashes are only updated along the committer's path which at this point has no unmerged leaves, however, there is no point in including unmerged leaves. 