### PR TITLE
Strong tree signing

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1122,7 +1122,7 @@ struct {
 } ParentHashInput;
 ~~~~~
 
-The Parent Hash of V with Co-Path Child S is the hash of a `ParentHashInput` object
+The Parent Hash of P with Co-Path Child S is the hash of a `ParentHashInput` object
 populated as follows. The field `public_key` contains the HPKE public key of P. If P
 is the root then `parent_hash` is set to the all-zeroes vector of size `Nh`.
 Otherwise `parent_hash` is the Parent Hash of P's parent with P's sibling as the

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1114,8 +1114,15 @@ opaque parent_hash<0..255>;
 
 This extension MUST be present in all Updates that are sent as part of a Commit
 message. If the extension is present, clients MUST verify that `parent_hash`
-matches the hash of the leaf's parent node when represented as a ParentNode
+matches the hash of the leaf's parent node when represented as a ParentHashInput
 struct.
+
+~~~~~
+struct {
+    HPKEPublicKey public_key;
+    opaque parent_hash<0..255>;
+} ParentHashInput;
+~~~~~
 
 <!-- OPEN ISSUE: This scheme, in which the tree hash covers the parent hash, is
 designed to allow for more deniable deployments, since a signature by a member
@@ -1150,9 +1157,8 @@ struct {
 } optional<T>;
 
 struct {
-    HPKEPublicKey public_key;
+    ParentHashInput parent_hash_input;
     uint32 unmerged_leaves<0..2^32-1>;
-    opaque parent_hash<0..255>;
 } ParentNode;
 ~~~~~
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1182,7 +1182,7 @@ Note that the `node_index` field contains the index of the leaf among the nodes
 in the tree, not its index among the leaves; `node_index = 2 * leaf_index`.
 
 Now the tree hash of any non-leaf node is recursively defined to be the hash of
-its `ParentNodeTreeHashInput`. This includes an optional `ParentNodeTreeHashData`
+its `ParentNodeTreeHashInput`. This includes an optional `ParentNode`
 object depending on if the node is blank or not.
 
 ~~~~~

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1122,16 +1122,16 @@ This extension MUST be present in the `leaf_key_package` Key Package field of an
 `UpdatePath` object. When processing a Commit message clients MUST recompute the 
 expected value of `parent_hash` for the committer's new leaf and verify that it 
 matches the `parent_hash` value in the `leaf_key_package`. Moreover, when joining
-a group new members MUST verify that if a leaf contains a `parent_hash` value than
+a group new members MUST verify that if a leaf contains a `parent_hash` value, then
 it matches the value obtained by recomputing `parent_hash` at the leaf.
 
 The `parent_hash` at the root is `0`. To compute the parent hash at a non-root
-node v with parent p and sibling u the `ParentHashInput` struct is used. It
-consists of three fields. The first contains the HPKE public key of p. The second
-contains the `parent_hash` at p. The third contains the list of HPKE public
-keys to which the HPKE secret key of v's parent was sent. That is, it consists of
+node V with parent P and sibling S, the `ParentHashInput` struct is used. It
+consists of three fields: The first contains the HPKE public key of P. The second
+contains the `parent_hash` at P. The third contains the list of HPKE public
+keys to which the HPKE secret key of P was sent to. That is, it consists of
 the array of `HPKEPublicKey` values of the nodes in the resolution of u but with
-the keys of p's `unmerged_leaves` omitted. 
+the`unmerged_leaves` of P omitted. 
 
 For example, in the ratchet tree depicted in {{resolution-example}} the
 `ParentHashInput` struct for node 6 would contain an empty array as the sibling of
@@ -1168,7 +1168,7 @@ struct {
 } optional<T>;
 ~~~~~
 
-The tree hash a leaf node is the hash of leaf's `LeafNodeHashInput` object which
+The tree hash of a leaf node is the hash of leaf's `LeafNodeHashInput` object which
 might include a Key Package depending on whether or not it is blank.
 
 ~~~~~

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1122,9 +1122,10 @@ struct {
 ~~~~~
 
 The Parent Hash of P with Co-Path Child S is the hash of a `ParentHashInput` object
-populated as follows. Field `public_key` contains the HPKE public key of P. If P is
-the root then `parent_hash` is set to the all-zeroes vector of size `Nh`. Otherwise
-`parent_hash` is the Parent Hash of P's parent with P's sibling as the co-path child.
+populated as follows. The field `public_key` contains the HPKE public key of P. If P
+is the root then `parent_hash` is set to the all-zeroes vector of size `Nh`.
+Otherwise `parent_hash` is the Parent Hash of P's parent with P's sibling as the
+co-path child.
 
 Finally, `original_child_resolution` is the array of `HPKEPublicKey` values of the
 nodes in the resolution of S but with the `unmerged_leaves` of P omitted. For

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1,4 +1,4 @@
---- 
+---
 title: The Messaging Layer Security (MLS) Protocol
 abbrev: MLS
 docname: draft-ietf-mls-protocol-latest
@@ -1119,8 +1119,8 @@ opaque parent_hash<0..255>;
 ~~~~~
 
 This extension MUST be present in the `leaf_key_package` Key Package field of an
-`UpdatePath` object. When processing a Commit message clients MUST recompute the 
-expected value of `parent_hash` for the committer's new leaf and verify that it 
+`UpdatePath` object. When processing a Commit message clients MUST recompute the
+expected value of `parent_hash` for the committer's new leaf and verify that it
 matches the `parent_hash` value in the `leaf_key_package`. Moreover, when joining
 a group new members MUST verify that if a leaf contains a `parent_hash` value, then
 it matches the value obtained by recomputing `parent_hash` at the leaf.
@@ -1130,8 +1130,8 @@ node V with parent P and sibling S, the `ParentHashInput` struct is used. It
 consists of three fields: The first contains the HPKE public key of P. The second
 contains the `parent_hash` at P. The third contains the list of HPKE public
 keys to which the HPKE secret key of P was sent to. That is, it consists of
-the array of `HPKEPublicKey` values of the nodes in the resolution of u but with
-the`unmerged_leaves` of P omitted. 
+the array of `HPKEPublicKey` values of the nodes in the resolution of S but with
+the`unmerged_leaves` of P omitted.
 
 For example, in the ratchet tree depicted in {{resolution-example}} the
 `ParentHashInput` struct for node 6 would contain an empty array as the sibling of
@@ -1153,7 +1153,7 @@ To allow group members to verify that they agree on the public cryptographic sta
 of the group, this section defines a scheme for generating a hash value (called
 the "tree hash") that represents the contents of the group's ratchet tree and the
 members' KeyPackages. The tree hash of a tree is the tree hash of its root node,
-which we define recursively, starting with the leaves. 
+which we define recursively, starting with the leaves.
 
 As some nodes may be blank while others contain data we use the following struct
 to include data if present.
@@ -1201,7 +1201,7 @@ struct {
 ~~~~~
 
 The `left_hash` and `right_hash` fields hold the tree hashes of the node's
-left and right children, respectively. 
+left and right children, respectively.
 
 ## Group State
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1141,9 +1141,9 @@ array with the HPKE public key's of nodes 5 and 6.
 
 ~~~~~
 struct {
-	HPKEPublicKey parents_public_key;
-	opaque parents_parent_hash<0..255>;
-	HPKEPublicKey original_sibling_resolution<0..2^32-1>;
+    HPKEPublicKey public_key;
+    opaque parent_hash<0..255>;
+    HPKEPublicKey original_child_resolution<0..2^32-1>;
 } ParentHashInput;
 ~~~~~
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1103,7 +1103,7 @@ opaque key_id<0..2^16-1>;
 
 ## Parent Hash
 
-The `parent_hash` extension serves to contain the adverse effect by a malicous 
+The `parent_hash` extension serves to contain the adverse effect of a malicous 
 member lying about the state of the ratchet tree when they send Welcome messages 
 to new members. It binds a KeyPackage to all subtrees it is contained in of the 
 group's ratchet tree, enables joining members to verify that each subtree is 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2752,7 +2752,9 @@ welcome_key = KDF.Expand(welcome_secret, "key", key_length)
     children are non-empty and have the hash of this node set as their
     `parent_hash` value (if the child is another parent) or has a `parent_hash`
     extension in the KeyPackage containing the same value (if the child is a
-    leaf).
+    leaf). If either of the node's children is empty, and in particular does not
+	have a parent hash, then its respective children's `parent_hash` values have
+	to be considered instead.
 
   * For each non-empty leaf node, verify the signature on the KeyPackage.
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2759,8 +2759,8 @@ welcome_key = KDF.Expand(welcome_secret, "key", key_length)
     `parent_hash` value (if the child is another parent) or has a `parent_hash`
     extension in the KeyPackage containing the same value (if the child is a
     leaf). If either of the node's children is empty, and in particular does not
-	have a parent hash, then its respective children's `parent_hash` values have
-	to be considered instead.
+    have a parent hash, then its respective children's `parent_hash` values have
+    to be considered instead.
 
   * For each non-empty leaf node, verify the signature on the KeyPackage.
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1120,15 +1120,15 @@ opaque parent_hash<0..255>;
 
 This extension MUST be present in the `leaf_key_package` Key Package field of an
 `UpdatePath` object. When processing a Commit message clients MUST recompute the 
-expected value of `parent_hash` for the commitor's new leaf and verify that it 
+expected value of `parent_hash` for the committer's new leaf and verify that it 
 matches the `parent_hash` value in the `leaf_key_package`. Moreover, when joining
 a group new members MUST verify that if a leaf contains a `parent_hash` value than
 it matches the value obtained by recomputing `parent_hash` of the leaf.
 
-To compute the parent hash of a node v, the `ParentHashInput` struct is used. It
-consists of two fields. The first contains the hash of data taken from v's parent,
-represented as a `ParentNodeData` struct (unless v is the root in which case 
-`parent_node_data` is set to `0`). The second field contains the list of HPKE public
+To compute the parent hash of a non-root node v (the root's `parent_hash` is set 
+to `0`), the `ParentHashInput` struct is used. It consists of two fields. The 
+first contains the hash of data taken from v's parent, represented as a 
+`ParentNodeData` struct. The second field contains the list of HPKE public
 keys to which the HPKE secret key of v's parent was sent. That is, it consists of
 the array of `HPKEPublicKey` values corresponding to the resolution of v's sibling
 node but with the keys v's parent's `unmerged_leaves` omitted. For example, in the

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1134,7 +1134,7 @@ the array of `HPKEPublicKey` values corresponding to the resolution of v's sibli
 node but with the keys v's parent's `unmerged_leaves` omitted. For example, in the
 ratchet tree depicted in {{resolution-example}} the `ParentHashInput` struct for
 node 6 would contain an empty array as the sibling of 6 is node 4 which has only
-itself in its resolution and node 4 is also an unmerged leaf for 6's parentl node 5.
+itself in its resolution and node 4 is also an unmerged leaf for 6's parent node 5.
 Meanwhile, the `ParentHashInput` of node 1 is an array with the HPKE public key's 
 of nodes 5 and 6.
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1160,9 +1160,18 @@ To this end, when processing a Commit message clients MUST recompute the
 expected value of `parent_hash` for the committer's new leaf and verify that it
 matches the `parent_hash` value in the supplied `leaf_key_package`. Moreover, when
 joining a group, new members MUST authenticate each non-blank parent node P. A parent
-node P is authenticated by checking that it has children V and S such that V's
-`ParentNode` struct has its `parent_hash` field set to the Parent Hash of P with
-Co-Path Child S.
+node P is authenticated by performing the following check: 
+
+* Let L and R be the left and right children of P, respectively
+* If L.parent_hash is equal to the Parent Hash of P with Co-Path Child R, the check passes 
+* If R is blank, replace R with its left child until R is either non-blank or a leaf node
+* If R is a leaf node, the check fails
+* If R.parent_hash is equal to the Parent Hash of P with Co-Path Child L, the check passes
+* Otherwise, the check fails
+
+The left-child recursion under the right child of P is necessary because the expansion of 
+the tree to the right due to Add proposals can cause blank nodes to be interposed 
+between a parent node and its right child. 
 
 ## Tree Hashes
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1,4 +1,4 @@
----
+--- 
 title: The Messaging Layer Security (MLS) Protocol
 abbrev: MLS
 docname: draft-ietf-mls-protocol-latest

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1118,7 +1118,7 @@ invariant.)
 opaque parent_hash<0..255>;
 ~~~~~
 
-This extension MUST be present in the `leaf_key_package` Key Package field of an
+This extension MUST be present in the `leaf_key_package` field of an
 `UpdatePath` object. When processing a Commit message clients MUST recompute the
 expected value of `parent_hash` for the committer's new leaf and verify that it
 matches the `parent_hash` value in the `leaf_key_package`. Moreover, when joining

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1124,7 +1124,7 @@ struct {
 
 The Parent Hash of P with Co-Path Child S is the hash of a `ParentHashInput` object
 populated as follows. The field `public_key` contains the HPKE public key of P. If P
-is the root then `parent_hash` is set to the all-zeroes vector of size `Nh`.
+is the root, then `parent_hash` is set to a zero-length octet string.
 Otherwise `parent_hash` is the Parent Hash of P's parent with P's sibling as the
 co-path child.
 
@@ -1134,12 +1134,12 @@ example, in the ratchet tree depicted in {{resolution-example}} the
 `ParentHashInput` of node 5 with co-path child 4 would contain an empty
 `original_child_resolution` since 4's resolution includes only itself but 4 is also
 an unmerged leaf of 5. Meanwhile, the `ParentHashInput` of node 5 with co-path child
-6 has an array with one element in it; namely the HPKE public key of 6.
+6 has an array with one element in it: the HPKE public key of 6.
 
 ### Using Parent Hashes
 
 The Parent Hash of P appears in three types of structs. If V is itself a parent node
-then the P's Parent Hash is stored in the `parent_hash` fields of both V's
+then P's Parent Hash is stored in the `parent_hash` fields of both V's
 `ParentHashInput` struct and V's `ParentNode` struct. (The `ParentNode` struct is
 used to encapsulate all public information about V that must be conveyed to a new
 member joining the group as well as to define the Tree Hash of node V.)

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1187,10 +1187,10 @@ object depending on if the node is blank or not.
 
 ~~~~~
 struct {
-	HPKEPublicKey public_key;
-	opaque parent_hash<0..255>;
+    HPKEPublicKey public_key;
+    opaque parent_hash<0..255>;
     uint32 unmerged_leaves<0..2^32-1>;
-} ParentNodeTreeHashData;
+} ParentNode;
 
 struct {
     uint32 node_index;

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1131,7 +1131,7 @@ consists of three fields: The first contains the HPKE public key of P. The secon
 contains the `parent_hash` at P. The third contains the list of HPKE public
 keys to which the HPKE secret key of P was sent to. That is, it consists of
 the array of `HPKEPublicKey` values of the nodes in the resolution of S but with
-the`unmerged_leaves` of P omitted.
+the `unmerged_leaves` of P omitted.
 
 For example, in the ratchet tree depicted in {{resolution-example}} the
 `ParentHashInput` struct for node 6 would contain an empty array as the sibling of

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -656,7 +656,8 @@ Each node in a ratchet tree contains up to five values:
 * An ordered list of leaf indices for "unmerged" leaves (see
   {{views}})
 * A credential (only for leaf nodes)
-* A hash of the node's parent, as of the last time the node was changed.
+* A hash of certain information about the node's parent, as of the last time the
+  node was changed (see {{parent-hash}}).
 
 The conditions under which each of these values must or must not be
 present are laid out in {{views}}.
@@ -1101,17 +1102,17 @@ an explicit, application-defined identifier to a KeyPackage.
 opaque key_id<0..2^16-1>;
 ~~~~~
 
-## Parent Hash
+## Parent Hash {#parent-hash}
 
-Consider a ratchet tree with a parent node P and children V and S. Suppose an
-`UpdatePath` object is applied to a ratchet tree along a path traversing node V.
-This defines a new Parent Hash value for all parent nodes on the updated path
-including P. The new "Parent Hash of P (with Co-Path Child S)" is obtained by hashing
-P's `ParentHashInput` struct using the resolution of S to populate the
-`original_child_resolution` field. P's Parent Hash fixes the new HPKE public keys
-of all nodes on the path from P to the root. Furthermore, for each such key PK the
-hash also binds the set of HPKE public keys to which PK's secret key was encrypted
-in the commit packet that anounced the `UpdatePath` object.
+Consider a ratchet tree with a parent node P and children V and S. The parent hash
+of P changes whenever an `UpdatePath` object is applied to the ratchet tree along
+a path traversing node V (and hence also P). The new "Parent Hash of P (with Co-Path
+Child S)" is obtained by hashing P's `ParentHashInput` struct using the resolution
+of S to populate the `original_child_resolution` field. This way, P's Parent Hash
+fixes the new HPKE public keys of all nodes on the path from P to the root.
+Furthermore, for each such key PK the hash also binds the set of HPKE public keys
+to which PK's secret key was encrypted in the commit packet that anounced the
+`UpdatePath` object.
 
 ~~~~~
 struct {
@@ -1121,7 +1122,7 @@ struct {
 } ParentHashInput;
 ~~~~~
 
-The Parent Hash of P with Co-Path Child S is the hash of a `ParentHashInput` object
+The Parent Hash of V with Co-Path Child S is the hash of a `ParentHashInput` object
 populated as follows. The field `public_key` contains the HPKE public key of P. If P
 is the root then `parent_hash` is set to the all-zeroes vector of size `Nh`.
 Otherwise `parent_hash` is the Parent Hash of P's parent with P's sibling as the


### PR DESCRIPTION
This pull request makes editorial changes to the definition of Tree Hash  to hopefully make it easier to understand.

It also redefines Parent Hash to include the HPKE public keys to which a nodes secret key was sent. This binds a key package introduced to the ratchet tree in a commit not just to the HPKE keys on the commits direct path but also (indirectly) to the other members that were sent each of the new (secret) keys. 

In particular, this prevents the attacks from the mailinglist that allowed an attacker to create artificial ratchet trees where the tree invariant was violated (which in turn lead to removes failing). But parent_hash only includes the HPKE pubkeys in the resolution so at least some amount of deniability might be preserved.