### PR TITLE
Identities SHOULD be unique per group

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2185,10 +2185,11 @@ leaf in the tree, for the second Add, the next empty leaf to the right, etc.
   public key from the KeyPackage in the Add, as well as the credential under
   which the KeyPackage was signed
 
-The identity contained in the credential of the `key_package` should be unique
-in the context of the group.  While the proposer can not necessarily know if that
-is the case, the committer of the proposal SHOULD consider the proposal invalid
-if a credential with the same identity is already present in the group.
+The identity, as well as the signature key contained in the credential of the
+`key_package` MUST be unique in the context of the group. While the proposer can
+not necessarily know if that is the case, the committer of the proposal MUST
+consider the proposal invalid if a credential with the same identity is already
+present in the group.
 
 ### Update
 
@@ -2376,10 +2377,11 @@ Update for the leaf if there are no Removes. If there are multiple Add proposals
 referencing the same `key_package`, the committer again chooses one to include
 and considers the rest invalid.
 
-If there are multiple Add proposals of KeyPackages with the same identity, the
-committer SHOULD choose one and consider the rest invalid. Similarly, if there
-are Add proposals of KeyPackages with an identity that is already present as a
-member of the group, the committer SHOULD consider them invalid.
+If there are multiple Add proposals of KeyPackages with the same identity or
+signature key, the committer MUST choose one and consider the rest invalid.
+Similarly, if there are Add proposals of KeyPackages with an identity or
+signature key that is already present as a member of the group, the committer
+MUST consider them invalid.
 
 The Commit MUST NOT combine proposals sent within different epochs. In the event
 that a valid proposal is omitted from the next Commit, the sender of the

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2542,9 +2542,10 @@ A member of the group applies a Commit message by taking the following steps:
   any Update or Remove proposals, or if it's empty. Otherwise, the `path` value
   MAY be omitted.
 
-* If the `path` value is populated: Process the `path` value using the ratchet
-  tree the provisional GroupContext, to update the ratchet tree and generate the
-  `commit_secret`:
+* If the `path` value is populated: Verify that the identity and signature key
+  of the credential in the new leaf are unique for this group. Then process the
+  `path` value using the ratchet tree the provisional GroupContext, to update
+  the ratchet tree and generate the `commit_secret`:
 
   * Apply the UpdatePath to the tree, as described in
     {{synchronizing-views-of-the-tree}}, and store `key_package` at the

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2185,6 +2185,11 @@ leaf in the tree, for the second Add, the next empty leaf to the right, etc.
   public key from the KeyPackage in the Add, as well as the credential under
   which the KeyPackage was signed
 
+The identity contained in the credential of the `key_package` should be unique
+in the context of the group.  While the proposer can not necessarily know if that
+is the case, the committer of the proposal SHOULD consider the proposal invalid
+if a credential with the same identity is already present in the group.
+
 ### Update
 
 An Update proposal is a similar mechanism to Add with the distinction
@@ -2368,8 +2373,10 @@ If there are multiple proposals that apply to the same leaf, the committer
 chooses one and includes only that one in the Commit, considering the rest
 invalid. The committer MUST prefer any Remove received, or the most recent
 Update for the leaf if there are no Removes. If there are multiple Add proposals
-for the same client, the committer again chooses one to include and considers
-the rest invalid.
+referencing the same `key_package`, the committer again chooses one to include
+and considers the rest invalid. Similarly, if there are multiple Add proposals
+with KeyPackages belonging to the same identity, the committer SHOULD choose one
+and consider the rest invalid.
 
 The Commit MUST NOT combine proposals sent within different epochs. In the event
 that a valid proposal is omitted from the next Commit, the sender of the

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2374,9 +2374,13 @@ chooses one and includes only that one in the Commit, considering the rest
 invalid. The committer MUST prefer any Remove received, or the most recent
 Update for the leaf if there are no Removes. If there are multiple Add proposals
 referencing the same `key_package`, the committer again chooses one to include
-and considers the rest invalid. Similarly, if there are multiple Add proposals
-with KeyPackages belonging to the same identity, the committer SHOULD choose one
-and consider the rest invalid.
+and considers the rest invalid.
+
+If there are multiple Add proposals with KeyPackages belonging to the same
+identity, the committer SHOULD choose one and consider the rest invalid.
+Similarly, if there are Add proposals including KeyPackages belonging to an
+identity that is already present as a member of the group, the committer SHOULD
+consider them invalid.
 
 The Commit MUST NOT combine proposals sent within different epochs. In the event
 that a valid proposal is omitted from the next Commit, the sender of the

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2376,11 +2376,10 @@ Update for the leaf if there are no Removes. If there are multiple Add proposals
 referencing the same `key_package`, the committer again chooses one to include
 and considers the rest invalid.
 
-If there are multiple Add proposals with KeyPackages belonging to the same
-identity, the committer SHOULD choose one and consider the rest invalid.
-Similarly, if there are Add proposals including KeyPackages belonging to an
-identity that is already present as a member of the group, the committer SHOULD
-consider them invalid.
+If there are multiple Add proposals of KeyPackages with the same identity, the
+committer SHOULD choose one and consider the rest invalid. Similarly, if there
+are Add proposals of KeyPackages with an identity that is already present as a
+member of the group, the committer SHOULD consider them invalid.
 
 The Commit MUST NOT combine proposals sent within different epochs. In the event
 that a valid proposal is omitted from the next Commit, the sender of the

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -3125,7 +3125,7 @@ key derived from the group secrets.
 
 The second form of authentication is that group members can verify a message
 originated from a particular member of the group. This is guaranteed by a
-digital signature on each message from the sender's identity key.
+digital signature on each message from the sender's signature key.
 
 ## Forward Secrecy and Post-Compromise Security
 


### PR DESCRIPTION
This PR changes the draft such that it mandates identities SHOULD be unique per group.

In particular, a committer SHOULD only include one Add per identity if multiple are present and SHOULD NOT include Adds for identities that are already members of the group.

I also made the requirement more precise, that there shouldn't be multiple Adds for the same "client", which I change "client" to "KeyPackage".

The rationale here being that this change allows us to address group members by their identity rather than their leaf index, which would allow us to finally hide the fact that we're using a tree underneath from users of MLS.