### PR TITLE
Add changelog for draft-11

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -133,6 +133,18 @@ shared keys with costs that scale as the log of the group size.
 
 RFC EDITOR PLEASE DELETE THIS SECTION.
 
+draft-11
+
+- Include subtree keys in parent hash (\*)
+
+- Pin HPKE to draft-07 (\*)
+
+- Move joiner secret to the end of the first key schedule epoch (\*)
+
+- Add an AppAck proposal
+
+- Make initializations of transcript hashes consistent
+
 draft-10
 
 - Allow new members to join via an external Commit (\*)


### PR DESCRIPTION
Immediately after I published draft-11, @raphaelrobert noticed that I had failed to update the change log.  This PR adds it to the editor's copy, so that it will be included in future versions.