### PR TITLE
Make PreSharedKeys non optional in GroupSecrets

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2812,7 +2812,7 @@ struct {
 struct {
   opaque joiner_secret<1..255>;
   optional<PathSecret> path_secret;
-  optional<PreSharedKeys> psks;
+  PreSharedKeys psks;
 } GroupSecrets;
 
 struct {


### PR DESCRIPTION
Currently the `psks` field in `GroupSecrets` is optional. `PreSharedKeys` only contains an array, which can be empty, even if the option is not empty. To avoid undefined behavior, I removed the option. In case no PSKs are used, the array should simply be empty.