### PR TITLE
Clarify which extensions should go into the group context

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1266,6 +1266,9 @@ The fields in this state have the following semantics:
   group, as described in {{tree-hashes}}.
 * The `confirmed_transcript_hash` field contains a running hash over
   the messages that led to this state.
+* The `extensions` field is populated by the extensions set upon creation of the
+  group. In particular, this pertains to extensions that have the `Message` type
+  `GC` (see {{mls-extension-types}}).
 
 When a new member is added to the group, an existing member of the
 group provides the new member with a Welcome message.  The Welcome

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -3412,6 +3412,7 @@ Template:
 
   * KP: KeyPackage messages
   * GI: GroupInfo objects
+  * GC: GroupContext objects
 
 * Recommended: Whether support for this extension is recommended by the IETF MLS
   WG.  Valid values are "Y" and "N".  The "Recommended" column is assigned a


### PR DESCRIPTION
Just a small editorial change to clarify which extensions should be included in the `GroupContext`. There is a paragraph explaining that the `RatchetTreeExtension` should not go in, but I think the section on the `GroupContext` should be precise about what _does_ go in.

I did notice, though, that we currently don't have a way of actually changing extensions during the lifetime of the group. If someone wanted to change an extensions, they would currently have to re-init the whole group. Of course, this could be solved by an extension, but maybe it would be sensible to have an `Extension` proposal for that purpose?