### PR TITLE
An entropy pool design for MLS

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -3284,6 +3284,31 @@ that a Commit is well-formed comprises an acknowledgement from one member per
 node in the UpdatePath, that is, one member from each subtree rooted in the
 copath node corresponding to the node in the UpdatePath.
 
+## Improving Resiliance to Poor Random Number Generators
+
+The security of a group hinges on the fact that every member has access to a
+good source of entropy. To make the protocol more robust in environments with
+weak sources of entropy or even compromised random number generators, each MLS
+implementation MUST maintain a `base_secret` and a `base_derivation_counter`,
+which act as an entropy pool.
+
+In the course of MLS protocol operations, whenever a client has to sample a
+fresh secret, new randomness is sampled from the underlying entropy source (e.g.
+the RNG of the operating system) and extracted together with the `base_secret`
+to form the new `base_secret`. The fresh secret is then derived from the
+`base_secret` and the value of the `base_derivation_counter`.
+
+Additionally, whenever a client processes a commit message in one of its groups,
+an extra secret is derived from the resulting `epoch_secret` with the label
+`base_secret_addition`. That secret is then Expanded together with the
+`base_secret` to form a new `base_secret`.
+
+TODO:
+* Formally specify the extract and expand calls
+* think of better names
+* do we actually need the counter?
+* should the secret derived from the `epoch_secret` be part of the Key Schedule?
+
 # IANA Considerations
 
 This document requests the creation of the following new IANA registries:

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -448,8 +448,8 @@ directly to the new member (there's no need to send it to the group). Only after
 A has received its Commit message back from the server does it update its state
 to reflect the new member's addition.
 
-Upon receiving the Welcome message, the new member will be able to read and send 
-new messages to the group. Messages received before the client has joined the 
+Upon receiving the Welcome message, the new member will be able to read and send
+new messages to the group. Messages received before the client has joined the
 group are ignored.
 
 ~~~~~
@@ -3301,7 +3301,7 @@ clients can obtain the value by "extracting" it from their entropy pool (e.g.
 when generating a new KeyPackage or fresh `leaf_secret`).
 
 Whenever enough entropy has accumulated in a pool all subsequent values extracted
-from it will look as if they were sampled from a truly uniform random and independant
+from it will look as if they were sampled from a truly uniform random and independent
 entropy source. This holds even if an adversary can control all inputs mixed into the
 pool after is has accumulated enough entropy. Pools can accumulate sufficient entropy
 either by being initialized using a good source of randomness or by having sufficient
@@ -3311,13 +3311,13 @@ extracting a value. Conversely, to ensure that Post-Compromise Security (PCS) ca
 achieved again after `entropy_pool` was leaked to an adversary, fresh entropy must be
 regularly mixed in to the pool.
 
-Clients obtain inputs to mix in to their pool both from external sources (such as th
+Clients obtain inputs to mix in to their pool both from external sources (such as the
 OS's RNG) and internal sources (i.e. exported from key schedules of ongoing MLS
-sessions). Mixing in internal sources can allow clients with no local source of
+groups). Mixing in internal sources can allow clients with no local source of
 entropy to piggyback off of the entropy sources of other members in a secure group
 chat. A pool SHOULD be shared between all MLS sessions on the client as this can lead
 to more diverse sources of internal input improving the likelyhood that, at any given
-moment, the pool contains sufficient entropy. 
+moment, the pool contains sufficient entropy.
 
 To extract a fresh value (denoted `fresh_secret`) for use in an MLS session clients
 MUST first mix in a new `uint64 external_entropy` sampled from an external RNG.
@@ -3346,9 +3346,9 @@ the client's leaf in the new epoch.
 
 ~~~~~
 struct {
-	opaque group_id<0..255>;
+  opaque group_id<0..255>;
     uint64 epoch;
-	uint32 leaf_index;
+  uint32 leaf_index;
 } InternalInputContext
 
 internal_entropy =

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -3289,25 +3289,62 @@ copath node corresponding to the node in the UpdatePath.
 The security of a group hinges on the fact that every member has access to a
 good source of entropy. To make the protocol more robust in environments with
 weak sources of entropy or even compromised random number generators, each MLS
-implementation MUST maintain a `base_secret` and a `base_derivation_counter`,
-which act as an entropy pool.
+implementation MUST maintain an `entropy_pool_secret`. The `entropy_pool_secret`
+serves as a source of entropy, which is used to derive fresh secrets whenever
+needed, for example when generating a new KeyPackage for an Update operation.
 
-In the course of MLS protocol operations, whenever a client has to sample a
-fresh secret, new randomness is sampled from the underlying entropy source (e.g.
-the RNG of the operating system) and extracted together with the `base_secret`
-to form the new `base_secret`. The fresh secret is then derived from the
-`base_secret` and the value of the `base_derivation_counter`.
+To ensure that Post-Compromise Security (PCS) can be achieved, the
+`entropy_pool_secret` must be injected with fresh entropy from some other
+source, such as the Random Number Generator (RNG) of the operating system.
 
-Additionally, whenever a client processes a commit message in one of its groups,
-an extra secret is derived from the resulting `epoch_secret` with the label
-`base_secret_addition`. That secret is then Expanded together with the
-`base_secret` to form a new `base_secret`.
+To achieve Forward Secrecy, the `entropy_pool_secret` is additionally "ratcheted
+forward" after each extraction of a fresh secret.
 
-TODO:
-* Formally specify the extract and expand calls
-* think of better names
-* do we actually need the counter?
-* should the secret derived from the `epoch_secret` be part of the Key Schedule?
+~~~~~
+             entropy_pool_secret_[n-1]
+                        |
+                        V
+fresh_randomness -> KDF.Extract = intermediate_secret
+                        |
+                        +--> DeriveSecret(., "mls_secret")
+                        |    = fresh_secret
+                        |
+                        V
+                  DeriveSecret(., "entropy_pool_secret")
+                  = entropy_pool_secret_[n]
+~~~~~
+
+The entropy gathered in the `entropy_pool_secret`, can be further increased by
+injecting addtional entropy whenever a group is updated by another party.
+
+If that is the case, the each party that did not perform the update operation
+themselves can update their `entropy_pool_secret` by injecting a secret derived
+from the updated group's key schedule. To that end, they first derive an
+`external_secret` as follows, where `epoch_secret` is the taken from the group's
+key schedule and `leaf_id` is the index of the party's leaf in the group:
+
+~~~~~
+external_secret =
+    ExpandWithLabel(`epoch_secret`, "entropy_pool_update", leaf_id, KDF.Nh)
+~~~~~
+
+The resulting `external_secret` can then be injected into the entropy pool as follows.
+~~~~~
+             entropy_pool_secret_[n-1]
+                        |
+                        V
+external_secret -> KDF.Extract = intermediate_secret
+                        |
+                        V
+                  DeriveSecret(., "entropy_pool_secret")
+                  = entropy_pool_secret_[n]
+~~~~~
+
+Even though each group member can derive the `external_secret` for every other
+member of the group, the resulting `entropy_pool_secret_[n]` is still secure as
+long as the preceding `entropy_pool_secret_[n-1]` was secure. As a consequence,
+this operation strictly improves the quality of the gathered entropy.
+
 
 # IANA Considerations
 


### PR DESCRIPTION
This PR mandates the use of an entropy pool for MLS and proposes a design that is modeled after the key schedule such that it
1) allows the extraction of entropy when needed,
2) allows the repeated injection of entropy originating from the system's RNG such that the entropy pool gets refreshed after a full state compromise,
3) gathers entropy over time while maintaining forward-secrecy,
4) allows the safe injection of entropy originating from other parties.

In particular, the design is such that we achieve what we believe are the best possible security guarantees from any injection operation:
* if the entropy from the system's RNG is good, the result is good independent of any other input to the pool
* if the entropy from one of the groups is good, the result is good independent of any other input to the pool

TODO:
* allow the injection of auxiliary randomness, for example a signature using a long term signature key as suggested by https://eprint.iacr.org/2018/1057