### PR TITLE
Explicit blank cases in MLSPlaintextTBS

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1929,6 +1929,10 @@ struct {
     select (MLSPlaintextTBS.sender.sender_type) {
         case member:
             GroupContext context;
+
+        case preconfigured:
+        case new_member:
+            struct{};
     }
 
     opaque group_id<0..255>;


### PR DESCRIPTION
The  `select` based on `MLSPlaintextTBS.sender.sender_type` seems ambiguous, as it does not state what happens to cases other than `member`. The TLS presentation language does not say anything on the matter.