### PR TITLE
Revisit the notion of identity in MLS groups

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2492,8 +2492,13 @@ If there are multiple proposals that apply to the same leaf, the committer
 chooses one and includes only that one in the Commit, considering the rest
 invalid. The committer MUST prefer any Remove received, or the most recent
 Update for the leaf if there are no Removes. If there are multiple Add proposals
-for the same client, the committer again chooses one to include and considers
-the rest invalid.
+containing KeyPackages with the same tuple `(credential.identity, endpoint_id)`
+the committer again chooses one to include and considers the rest invalid. Add
+proposals that contain KeyPackages with an `(credential.identity, endpoint_id)`
+tuple that matches that of an existing KeyPackage in the group MUST be
+considered invalid. The comitter MUST consider invalid any Add or Update
+proposal if the Credential in the contained KeyPackage shares the same signature
+key with a Credential in any leaf of the group.
 
 The Commit MUST NOT combine proposals sent within different epochs. In the event
 that a valid proposal is omitted from the next Commit, the sender of the
@@ -2570,8 +2575,11 @@ message at the same time, by taking the following steps:
   new member (from an add proposal) MUST be exluded from the resolution during
   the computation of the UpdatePath. The GroupContext for this operation uses
   the `group_id`, `epoch`, `tree_hash`, and `confirmed_transcript_hash` values
-  in the initial GroupContext object.  The `leaf_key_package` for this
-  UpdatePath must have a `parent_hash` extension.
+  in the initial GroupContext object. The `leaf_key_package` for this UpdatePath
+  must have a `parent_hash` extension. Note, that the KeyPackage in the
+  `UpdatePath` effectively updates an existing KeyPackage in the group and thus
+  MUST adhere to the same restrictions as KeyPackages used in `Update`
+  proposals.
 
    * Assign this UpdatePath to the `path` field in the Commit.
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1007,13 +1007,11 @@ provide some public information about a user. KeyPackage
 structures provide information about a client that any existing
 member can use to add this client to the group asynchronously.
 
-A KeyPackage object specifies a ciphersuite that the client
-supports, as well as providing a public key that others can use
-for key agreement. The client's signature key can be updated
-throughout the lifetime of the group by sending a new KeyPackage
-with a new Credential. However, the identity MUST be the same in
-both Credentials and the new Credential MUST be validated by the
-authentication service.
+A KeyPackage object specifies a ciphersuite that the client supports, as well as
+providing a public key that others can use for key agreement.
+
+The `identity` arising from the credential, together with the `endpoint_id` in
+the KeyPackage serve to uniquely identify a client in a group.
 
 When used as InitKeys, KeyPackages are intended to be used only once and SHOULD NOT
 be reused except in case of last resort. (See {{initkey-reuse}}).
@@ -1050,6 +1048,7 @@ struct {
     ProtocolVersion version;
     CipherSuite cipher_suite;
     HPKEPublicKey hpke_init_key;
+    opaque endpoint_id<0..255>;
     Credential credential;
     Extension extensions<8..2^32-1>;
     opaque signature<0..2^16-1>;

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2261,7 +2261,8 @@ struct {
 The KeyPackage contained in an `Update` proposal MUST share the values of the
 following fields with the KeyPackage it replaces in the tree: `version`,
 `cipher_suite`, `credential.identity`, `endpoint_id`. However, it MUST NOT share
-a signature key with any other KeyPackage in the tree.
+a signature key with any other KeyPackage in the tree and it MUST NOT contain
+the same `hpke_init_key` as the KeyPackage it replaces.
 
 A member of the group applies an Update message by taking the following steps:
 
@@ -2498,7 +2499,8 @@ proposals that contain KeyPackages with an `(credential.identity, endpoint_id)`
 tuple that matches that of an existing KeyPackage in the group MUST be
 considered invalid. The comitter MUST consider invalid any Add or Update
 proposal if the Credential in the contained KeyPackage shares the same signature
-key with a Credential in any leaf of the group.
+key with a Credential in any leaf of the group, or indeed if the KeyPackage
+shares the same `hpke_init_key` with another KeyPackage in the group.
 
 The Commit MUST NOT combine proposals sent within different epochs. In the event
 that a valid proposal is omitted from the next Commit, the sender of the

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2262,11 +2262,13 @@ struct {
 } Update;
 ~~~~~
 
-The KeyPackage contained in an `Update` proposal MUST share the values of the
-following fields with the KeyPackage it replaces in the tree: `version`,
-`cipher_suite`, `credential.identity`, `endpoint_id`. However, it MUST NOT share
-a signature key with any other KeyPackage in the tree and it MUST NOT contain
-the same `hpke_init_key` as the KeyPackage it replaces.
+The values in the following fields of the KeyPackage contained in an `Update`
+proposal MUST be the same as those of the KeyPackage it replaces in the tree.
+`version`, `cipher_suite`, `credential.identity`, `endpoint_id`. However, the
+value of the `credential.signature_key` field of the new KeyPackage MUST be
+different from that of all other KeyPackages in the tree. Furthermore, the value
+of the `hpke_init_key` field of the new KeyPackage MUST be different from that
+of the KeyPackage it replaces.
 
 A member of the group applies an Update message by taking the following steps:
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2258,6 +2258,11 @@ struct {
 } Update;
 ~~~~~
 
+The KeyPackage contained in an `Update` proposal MUST share the values of the
+following fields with the KeyPackage it replaces in the tree: `version`,
+`cipher_suite`, `credential.identity`, `endpoint_id`. However, it MUST NOT share
+a signature key with any other KeyPackage in the tree.
+
 A member of the group applies an Update message by taking the following steps:
 
 * Replace the sender's leaf KeyPackage with the one contained in


### PR DESCRIPTION
After a discussion with @bifurcation and @raphaelrobert, this PR is a new spin on and an extension of #439.

This PR adds the `endpoint_id` field to KeyPackages. The `endpoint_id` field serves to distinguish KeyPackages with Credentials that share the value of their `identity` field.

This PR also introduces a set of restrictions for KeyPackages that introduced to the group via Adds and Updates.

Generally, for both Adds and Updates, the committer has to ensure that
- signature keys are unique within a group (this is so that the sender of a message can be determined uniquely within a group),
- `(identity, endpoint_id)` tuples are unique in a group,
- `hpke_init_key`s are unique in a group.

Additionally, Updates have to ensure that
- the new and the old key package have the same `identity` (in the Credential), `endpoint_id`, `version` and `cipher_suite` as the key package they replace,
- the new and the old key package do not share the same `hpke_init_key`.

I didn't extend the section indicating that the processor of a commit has to check all these things in the same way that the committer has to. I think, here we should probably restructure the section, so that we can just reference the part where it is specified how to determine if a given proposal is valid in the context of a given group.