### PR TITLE
Remove the notion of a 'leaf index'

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -635,6 +635,11 @@ are as follows:
 * 11 = EFG
 * 12 = G
 
+A tree with `n` leaves has `2*n - 1` nodes.  For example, the above tree has 7
+leaves (A, B, C, D, E, F, G) and 13 nodes.  The root of a tree with `n` leaves
+is always the node with index `2^k - 1`, where `k` is the largest number such
+that `2^k < n`.
+
 ## Ratchet Tree Nodes {#resolution-example}
 
 A particular instance of a ratchet tree is defined by the same parameters that

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -602,14 +602,13 @@ For example, in the below tree:
 * The copath of C is (D, AB, EFG)
 
 ~~~~~
-            ABCDEFG
-           /      \
-          /        \
-         /          \
-     ABCD            EFG
-    /    \          /  \
-   /      \        /    \
-  AB      CD      EF    |
+              7 = root
+        ______|______
+       /             \
+      3              11
+    __|__           __|
+   /     \         /   \
+  1       5       9     |
  / \     / \     / \    |
 A   B   C   D   E   F   G
 
@@ -677,9 +676,9 @@ brackets:
 
 ~~~~~
       _
-    /   \
+    __|__
    /     \
-  _       CD[C]
+  _       5[C]
  / \     / \
 A   _   C   D
 
@@ -765,13 +764,14 @@ leaf_priv, leaf_pub = KEM.DeriveKeyPair(leaf_node_secret)
 node_priv[n], node_pub[n] = KEM.DeriveKeyPair(node_secret[n])
 ~~~~~
 
-For example, suppose there is a group with four members:
+For example, suppose there is a group with four members, with C an unmerged leaf
+at node 5:
 
 ~~~~~
-     ABCD
-    /    \
-   /      \
-  AB      CD
+      3
+    __|__
+   /     \
+  1       5[C]
  / \     / \
 A   B   C   D
 
@@ -798,10 +798,10 @@ After applying the UpdatePath, the tree will have the following structure, where
 described above:
 
 ~~~~~
-   np[1] -> ABCD
-           /    \
-          /      \
-np[0] -> AB      CD
+    np[1] -> 3
+           __|__
+          /     \
+np[0] -> 1       5[C]
         / \     / \
        A   B   C   D
            ^
@@ -871,16 +871,16 @@ For example, in order to communicate the example update described in
 the previous section, the sender would transmit the following
 values:
 
-| Public Key    | Ciphertext(s)               |
-|:--------------|:----------------------------|
-| node_pub\[1\] | E(pk(CD), path_secret\[1\]) |
-| node_pub\[0\] | E(pk(A), path_secret\[0\])  |
+| Public Key    | Ciphertext(s)                                           |
+|:--------------|:--------------------------------------------------------|
+| node_pub\[1\] | E(pk(5), path_secret\[1\]), E(pk(C), path_secret\[1\])  |
+| node_pub\[0\] | E(pk(A), path_secret\[0\])                              |
 
 In this table, the value pk(ns\[X\]) represents the public key
 derived from the node secret X, whereas pk(X) represents the public leaf key
 for user X.  The value E(K, S) represents
 the public-key encryption of the path secret S to the
-public key K.
+public key K (using HPKE).
 
 After processing the update, each recipient MUST delete outdated key material,
 specifically:

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -650,7 +650,7 @@ Each node in a ratchet tree contains up to five values:
 
 * A private key (only within the member's direct path, see below)
 * A public key
-* An ordered list of leaf indices for "unmerged" leaves (see
+* An ordered list of node indices for "unmerged" leaves (see
   {{views}})
 * A credential (only for leaf nodes)
 * A hash of certain information about the node's parent, as of the last time the
@@ -672,7 +672,8 @@ of the node.
   of its right child, in that order
 
 For example, consider the following tree, where the "\_" character
-represents a blank node:
+represents a blank node and unmerged leaves are indicated in square
+brackets:
 
 ~~~~~
       _
@@ -767,13 +768,14 @@ node_priv[n], node_pub[n] = KEM.DeriveKeyPair(node_secret[n])
 For example, suppose there is a group with four members:
 
 ~~~~~
-      G
-     / \
-    /   \
-   /     \
-  E       _
+     ABCD
+    /    \
+   /      \
+  AB      CD
  / \     / \
 A   B   C   D
+
+0 1 2 3 4 5 6
 ~~~~~
 
 If member B subsequently generates an UpdatePath based on a secret
@@ -792,15 +794,21 @@ leaf_secret    --> leaf_node_secret --> leaf_priv, leaf_pub
 ~~~~~
 
 After applying the UpdatePath, the tree will have the following structure, where
-"np\[i\]" represents the node_priv values generated as described
-above:
+`lp` and `np[i]` represent the leaf_priv and node_priv values generated as
+described above:
 
 ~~~~~
-          np[1]
-         /     \
-     np[0]      _
-     /  \      / \
-    A    B    C   D
+   np[1] -> ABCD
+           /    \
+          /      \
+np[0] -> AB      CD
+        / \     / \
+       A   B   C   D
+           ^
+           |
+           lp
+
+       0 1 2 3 4 5 6
 ~~~~~
 
 After performing these operations, the generator of the UpdatePath MUST
@@ -863,10 +871,10 @@ For example, in order to communicate the example update described in
 the previous section, the sender would transmit the following
 values:
 
-| Public Key   | Ciphertext(s)                        |
-|:-------------|:-------------------------------------|
-| pk(ns\[1\])  | E(pk(C), ps\[1\]), E(pk(D), ps\[1\]) |
-| pk(ns\[0\])  | E(pk(A), ps\[0\])                    |
+| Public Key    | Ciphertext(s)               |
+|:--------------|:----------------------------|
+| node_pub\[1\] | E(pk(CD), path_secret\[1\]) |
+| node_pub\[0\] | E(pk(A), path_secret\[0\])  |
 
 In this table, the value pk(ns\[X\]) represents the public key
 derived from the node secret X, whereas pk(X) represents the public leaf key


### PR DESCRIPTION
After discussion at the interim 2021-10-04, there seemed to be agreement to move from having two sets of indices (leaf and node indices) to just using node indices.  The main impact of this is that wherever there is a node index in the protocol that is only ever supposed to refer to a leaf node (`Remove.removed`, `GroupInfo.signer_index`, `MLSPlaintext.sender.sender`, `PublicGroupState.signer_index`), the recipient of the message needs to verify that the node index is actually a leaf.  However, implementations already needed to check that these fields were populated leaves, so the change should be minor.

Implementations that were using typed message structures to separate node and leaf indices can continue to use those types to assure that validation is done.  They'll just have to multiply by two on serialize and divide on deserialize if they use leaf indices as before internally.

There are also a couple of small, unrelated, "drive-by" fixes in here:
* Clean up of notation in the ratchet tree section
* Including PublicGroupState signer index in signature (in parallel with GroupInfo)

Replaces #484 
Fixes #432 