### PR TITLE
Add a 'reserved' field to WireFormat

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1858,8 +1858,9 @@ struct {
 } MAC;
 
 enum {
-  mls_plaintext(0),
-  mls_ciphertext(1),
+  reserved(0),
+  mls_plaintext(1),
+  mls_ciphertext(2),
   (255)
 } WireFormat;
 


### PR DESCRIPTION
The `WireFormat` `enum` was not aligned with other enums in that it did not contain the mandatory `reserved` field.