### PR TITLE
Require PublicGroupStateTBS for external init

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1493,7 +1493,7 @@ information provided in the PublicGroupState and an external Commit to initializ
 their copy of the key schedule for the new epoch.
 
 ~~~~~
-kem_output, context = SetupBaseS(external_pub, PublicGroupState)
+kem_output, context = SetupBaseS(external_pub, PublicGroupStateTBS)
 init_secret = context.export("MLS 1.0 external init secret", KDF.Nh)
 ~~~~~
 
@@ -1501,7 +1501,7 @@ Members of the group receive the `kem_output` in an ExternalInit proposal and
 preform the corresponding calculation to retrieve the `init_secret` value.
 
 ~~~~~
-context = SetupBaseR(kem_output, external_priv, PublicGroupState)
+context = SetupBaseR(kem_output, external_priv, PublicGroupStateTBS)
 init_secret = context.export("MLS 1.0 external init secret", KDF.Nh)
 ~~~~~
 


### PR DESCRIPTION
There is really no benefit in requiring the whole PublicGroupState, inclucing signer and signature. Instead, this complicates things, since upon receiving a commit with an external init, the client has to fetch the PGS that was used for the external init, since they need it to compute the external init secret.

From what I can see, the only thing we really gain from using the signed PGS is a degree of attribution, where upon an external init, every group member knows who authored the PGS that was used for the external init. Feel free to disagree, but I don't think that's a property we really need here.

This PR makes it such that the `PublicGroupStateTBS` is used to compute the external init secret instead of the `PublicGroupState`.