### PR TITLE
Getting rid of the array representation

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1733,13 +1733,9 @@ in the ratchet.
 
 ~~~~
 DeriveTreeSecret(Secret, Label, Generation, Length) =
-    ExpandWithLabel(Secret, Label, RatchetContext, Length)
+    ExpandWithLabel(Secret, Label, Generation, Length)
 
-Where RatchetContext is specified as:
-
-struct {
-    uint32 generation = Generation;
-} RatchetContext;
+Where Generation is encoded as a uint32.
 ~~~~
 ~~~~~
 ratchet_secret_[N]_[j]

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1774,16 +1774,16 @@ forward secrecy for past messages. Members MAY keep unconsumed values around
 for some reasonable amount of time to handle out-of-order message delivery.
 
 For example, suppose a group member encrypts or (successfully) decrypts an
-application message using the j-th key and nonce in the ratchet of node
-N in some epoch n. Then, for that member, at least the following
+application message using the j-th key and nonce in the ratchet of leaf node
+L in some epoch n. Then, for that member, at least the following
 values have been consumed and MUST be deleted:
 
 * the `commit_secret`, `joiner_secret`, `epoch_secret`, `encryption_secret` of
   that epoch n as well as the `init_secret` of the previous epoch n-1,
 * all node secrets in the Secret Tree on the path from the root to the leaf with
-  node N,
-* the first j secrets in the application data ratchet of node N and
-* `application_ratchet_nonce_[N]_[j]` and `application_ratchet_key_[N]_[j]`.
+  node L,
+* the first j secrets in the application data ratchet of node L and
+* `application_ratchet_nonce_[L]_[j]` and `application_ratchet_key_[L]_[j]`.
 
 Concretely, suppose we have the following Secret Tree and ratchet for
 participant D:

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1198,10 +1198,10 @@ co-path child.
 Finally, `original_child_resolution` is the array of `HPKEPublicKey` values of the
 nodes in the resolution of S but with the `unmerged_leaves` of P omitted. For
 example, in the ratchet tree depicted in {{resolution-example}} the
-`ParentHashInput` of node 5 with co-path child 4 would contain an empty
-`original_child_resolution` since 4's resolution includes only itself but 4 is also
-an unmerged leaf of 5. Meanwhile, the `ParentHashInput` of node 5 with co-path child
-6 has an array with one element in it: the HPKE public key of 6.
+`ParentHashInput` of node CD with co-path child C would contain an empty
+`original_child_resolution` since C's resolution includes only itself but C is also
+an unmerged leaf of CD. Meanwhile, the `ParentHashInput` of node CD with co-path child
+D has an array with one element in it: the HPKE public key of D.
 
 ### Using Parent Hashes
 
@@ -2315,15 +2315,12 @@ struct {
 } Add;
 ~~~~~
 
-The proposer of the Add does not control where in the group's ratchet tree the
-new member is added.  Instead, the sender of the Commit message chooses a
-location for each added member and states it in the Commit message.
-
 An Add is applied after being included in a Commit message.  The position of the
-Add in the list of proposals determines the leaf index `index` of the leaf node
-where the new member will be added.  For the first Add in the Commit, `index` is
-the leftmost empty leaf in the tree, for the second Add, the next empty leaf to
-the right, etc.
+Add in the list of proposals determines the leaf node where the new member will
+be added.  For the first Add in the Commit, the corresponding new member will be
+placed in the leftmost empty leaf in the tree, for the second Add, the next
+empty leaf to the right, etc. If not empty leaf exists, the tree is extended to
+the right.
 
 * Validate the KeyPackage:
 
@@ -2344,15 +2341,16 @@ the right, etc.
       extension, then the required extensions and proposals MUST be listed in
       the KeyPackage's `capabilities` extension.
 
-* If necessary, extend the tree to the right until it has at least index + 1
-  leaves
+* Identify the leaf L for the new member: if there are empty leaves in the tree,
+  L is the leftmost empty leaf.  Otherwise, the tree is extended to the right
+  and L is the new leaf.
 
-* For each non-blank intermediate node along the path from the leaf at position
-  `index` to the root, add `index` to the `unmerged_leaves` list for the node.
+* For each non-blank intermediate node along the path from the leaf L
+  to the root, add L's leaf index to the `unmerged_leaves` list for the node.
 
-* Set the leaf node in the tree at position `index` to a new node containing the
-  public key from the KeyPackage in the Add, as well as the credential under
-  which the KeyPackage was signed
+* Set the leaf node L to a new node containing the public key from the
+  KeyPackage in the Add, as well as the credential under which the KeyPackage
+  was signed.
 
 ### Update
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -3166,8 +3166,58 @@ struct {
 optional<Node> ratchet_tree<1..2^32-1>;
 ~~~~~
 
-The nodes are listed in the in-order trasversal of the ratchet tree: each node
-is listed between its left subtree and its right subtree.
+The nodes are listed in the order specified by a left-to-right in-order
+traversal of the rachet tree. Each node is listed between its left subtree and
+its right subtree. The leaves of the tree are stored in even-numbered entries in
+the array (the leaf with index L in array position 2*L). The root node of the
+tree is at position 2^k - 1 of the array, where k is the largest number such
+that 2^k is smaller than the length of the array. Intermediate parent nodes can
+be identified by performing the same calculation to the subarrays to the left
+and right of the root, following something like the following algorithm:
+
+~~~~~
+# Assuming a class Node that has left and right members
+def subtree_root(nodes):
+    # If there is only one node in the array return it
+    if len(nodes) == 1:
+        return Node(nodes[0])
+
+    # Otherwise, the length of the array MUST be odd
+    if len(nodes) % 2 == 0:
+        raise Exception("Malformed node array {}", len(nodes))
+
+    # Identify the root of the subtree
+    k = 0
+    while (2**(k+1)) < len(nodes):
+       k += 1
+    R = 2**k - 1
+    root = Node(nodes[R])
+    root.left = subtree_root(nodes[:R])
+    root.right = subtree_root(nodes[(R+1):])
+    return root
+~~~~~
+
+The example tree in {{tree-computation-terminology}} would be represented as an
+array of nodes in the following form, where R represents the "subtree root" for
+a given subarray of the node array:
+
+~~~~~
+              7
+        ______|______
+       /             \
+      3              11
+    __|__           __|
+   /     \         /   \
+  1       5       9     |
+ / \     / \     / \    |
+A   B   C   D   E   F   G
+
+                    1 1 1
+0 1 2 3 4 5 6 7 8 9 0 1 2
+<-----------> R <------->
+<---> R <--->   <---> R -
+- R -   - R -   - R -
+~~~~~
 
 The presence of a `ratchet_tree` extension in a GroupInfo message does not
 result in any changes to the GroupContext extensions for the group.  The ratchet

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -644,17 +644,17 @@ siblings of all the nodes in its direct path, excluding the root.
 
 For example, in the below tree:
 
-* The direct path of C is (CD, ABCD, ABCDEFG)
-* The copath of C is (D, AB, EFG)
+* The direct path of C is (W, V, X)
+* The copath of C is (D, U, Z)
 
 ~~~~~
-           ABCDEFG = root
+              X = root
         ______|______
        /             \
-     ABCD            EFG
+      V               Z
     __|__           __|
    /     \         /   \
-  AB     CD       EF    |
+  U       W       Y     |
  / \     / \     / \    |
 A   B   C   D   E   F   G
 


### PR DESCRIPTION
Filing this on behalf of @TWal after discussions with @kkohbrok and @karthikbhargavan.

The idea behind it is that the array representation is only one possible implementation for the tree. This PR removes the reliance on nodes indices to address nodes in the tree.

I'll leave it to @TWal to write a more detailed description.