### PR TITLE
Be explicit that Credentials can attest to multiple identities

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1283,9 +1283,34 @@ The signatures used in this document are encoded as specified in {{!RFC8446}}.
 In particular, ECDSA signatures are DER-encoded and EdDSA signatures are defined
 as the concatenation of `r` and `s` as specified in {{?RFC8032}}.
 
-Note that each new credential that has not already been validated
-by the application MUST be validated against the Authentication
-Service.
+Each new credential that has not already been validated by the application MUST
+be validated against the Authentication Service.
+
+### Uniquely Identifying Clients
+
+MLS implementations will presumably provide applications with a way to request
+protocol operations with regard to other clients (e.g., removing clients).  Such
+functions will need to refer to the other clients using some identifier.  MLS
+clients have a few types of identifiers, with different operational properties.
+
+The Credentials presented by the clients in a group authenticate
+application-level identifiers for the clients.  These identifiers may not
+uniquely identify clients.  For example, if a user has multiple devices that are
+all present in an MLS group, then those devices' clients will all present the
+user's application-layer identifiers.
+
+Internally to the the protocol, group members are uniquely identified by their
+leaves, expressed as KeyPackageRef objects.  These identifiers are unstable:
+They change whenever the member sends a Commit, or whenever an Update
+proposal from the member is committed.
+
+MLS provides two unique client identifiers that are stable across epochs:
+
+* The index of a client among the leaves of the tree
+* The `epoch_id` field in the key package
+
+The application may also provide application-specific unique identifiers in the
+`extensions` field of KeyPackage object.
 
 # Key Packages
 
@@ -2507,7 +2532,7 @@ Note that these three steps may be done by the same group member or different
 members.  For example, if a group member sends a commit with an inline ReInit
 proposal (steps 1 and 2), but then goes offline, another group member may send
 the corresponding Welcome.  This flexibility avoids situations where a group
-gets stuck between steps 2 and 3. 
+gets stuck between steps 2 and 3.
 
 Resumption PSKs with usage `reinit` MUST NOT be used in other contexts.  A
 PreSharedKey proposal with type `resumption` and usage `reinit` MUST be

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1495,7 +1495,9 @@ The validity of a KeyPackage needs to be verified at a few stages:
 The client verifies the validity of a KeyPackage using the following steps:
 
 * Verify that the credential in the KeyPackage is valid according to the
-  authentication service and the client's local policy.
+  authentication service and the client's local policy.  These actions MUST be
+  the same regardless of at what point in the protocol the KeyPackage is being
+  verified.
 
 * Verify that the signature on the KeyPackage is valid using the public key
   in the KeyPackage's credential

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2679,6 +2679,9 @@ A member of the group applies an Update message by taking the following steps:
     * Verify that the signature on the KeyPackage is valid using the public key
       in the KeyPackage's credential
 
+    * Verify that the KeyPackage's credential is valid according to the
+      Authentication Service
+
     * Verify that the following fields in the KeyPackage are unique among the
       members of the group (including any other members added in the same
       Commit):
@@ -3162,6 +3165,9 @@ A member of the group applies a Commit message by taking the following steps:
 * If the `path` value is populated: Process the `path` value using the
   provisional ratchet tree and GroupContext, to generate the new ratchet tree
   and the `commit_secret`:
+
+  * Verify that the KeyPackage is acceptable according to the rules for Update
+    (see {{update}})
 
   * Apply the UpdatePath to the tree, as described in
     {{synchronizing-views-of-the-tree}}, and store `leaf_key_package` at the

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1284,7 +1284,9 @@ In particular, ECDSA signatures are DER-encoded and EdDSA signatures are defined
 as the concatenation of `r` and `s` as specified in {{?RFC8032}}.
 
 Each new credential that has not already been validated by the application MUST
-be validated against the Authentication Service.
+be validated against the Authentication Service.  Applications SHOULD require
+that a client present the same set of identifiers throughout its presence in
+the group, even if its Credential is changed in a Commit or Update.
 
 ### Uniquely Identifying Clients
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1286,7 +1286,11 @@ as the concatenation of `r` and `s` as specified in {{?RFC8032}}.
 Each new credential that has not already been validated by the application MUST
 be validated against the Authentication Service.  Applications SHOULD require
 that a client present the same set of identifiers throughout its presence in
-the group, even if its Credential is changed in a Commit or Update.
+the group, even if its Credential is changed in a Commit or Update.  If an
+application allows clients to change identifiers over time, then each time the
+client presents a new credential, the application MUST verify that the set
+of identifiers in the credential is acceptable to the application for this
+client.
 
 ### Uniquely Identifying Clients
 


### PR DESCRIPTION
The specification currently assumes that a Credential provides a singular identity for a client, when in reality that is not the case.  For example, X509Credential can provide a whole collection of identities, and it's up to the application to decide if its preferred identity is among them.  Just like in TLS, a server can send a cert with 100 domains, but the TLS client knows which one it's looking for.

This PR refactors the parts of the spec that refer to identity to be consistent with this idea.  The main impacts are to processing of Update and Remove-within-External-Commit, both cases in which you want the new KeyPackage to logically represent the same identity as the old one.

This PR also removes the `endpoint_id` field from KeyPackage.  Since we now reference KeyPackages by KeyPackageID, there's no longer a need for a separate identifier.  (Unless we want an identifier that's stable across epochs, but (a) it's not clear to me that that is needed in general and (b) it can easily be added in an extension, as in fact we have done in Webex.)