### PR TITLE
Remove explicit version pin on HPKE

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -954,7 +954,7 @@ following primitives to be used in group key computations:
 * A hash algorithm
 * A signature algorithm
 
-MLS uses draft-08 of HPKE {{I-D.irtf-cfrg-hpke}} for public-key encryption.
+MLS uses HPKE for public-key encryption {{I-D.irtf-cfrg-hpke}}.
 The `DeriveKeyPair` function associated to the KEM for the ciphersuite maps
 octet strings to HPKE key pairs.
 


### PR DESCRIPTION
HPKE is in the RFC Editor queue, so there shouldn't be any further changes.

Fixes #500 