### PR TITLE
Unambiguous signatures

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -3348,7 +3348,6 @@ welcome_nonce = KDF.Expand(welcome_secret, "nonce", AEAD.Nn)
 welcome_key = KDF.Expand(welcome_secret, "key", AEAD.Nk)
 ~~~~~
 
-
 * Verify the signature on the GroupInfo object. The signature input comprises
   all of the fields in the GroupInfo object except the signature field. The
   public key and algorithm are taken from the credential in the leaf node of the

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1177,7 +1177,7 @@ VerifyWithLabel(VerificationKey, Label, Content) =
 Where SignContent is specified as:
 
 struct {
-    opaque label<7..255> = "mls10 " + Label;
+    opaque label<9..255> = "MLS 1.0 " + Label;
     opaque content<0..2^32-1> = Content;
 } SignContent;
 ~~~~~

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2231,15 +2231,6 @@ group and epoch.
 
 ~~~~~
 struct {
-    select (MLSPlaintextTBS.sender.sender_type) {
-        case member:
-            GroupContext context;
-
-        case preconfigured:
-        case new_member:
-            struct{};
-    }
-
     WireFormat wire_format;
     opaque group_id<0..255>;
     uint64 epoch;
@@ -2256,6 +2247,15 @@ struct {
 
         case commit:
           Commit commit;
+    }
+
+    select (MLSPlaintextTBS.sender.sender_type) {
+        case member:
+            GroupContext context;
+
+        case preconfigured:
+        case new_member:
+            struct{};
     }
 } MLSPlaintextTBS;
 ~~~~~


### PR DESCRIPTION
Signatures as specified in the MLS protocol document are ambiguous, in the sense that signatures produced for one purpose in the protocol can be (maliciously) used in a different place of the protocol.
Indeed, we found that for example, a `KeyPackage` can have the same serialization as `MLSPlaintextTBS`, which proves that one signature could be accepted for different structures.

The collisions we have found so far are quite artificial, so it is not super clear how to exploit this, but at least it makes it impossible to have provable security.

The solution is pretty simple, we simply prefix each signed value with a label, in a fashion similar to `ExpandWithLabel`.
That way, when calling `SignWithLabel` you can give the structure name in the `Label` argument.