### PR TITLE
Stronger parent hashes for authenticated identities

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1205,7 +1205,7 @@ to which PK's secret key was encrypted in the commit packet that anounced the
 struct {
     HPKEPublicKey public_key;
     opaque parent_hash<0..255>;
-    HPKEPublicKey original_child_resolution<0..2^32-1>;
+    opaque original_sibling_tree_hash<0..255>;
 } ParentHashInput;
 ~~~~~
 
@@ -1215,13 +1215,34 @@ is the root, then `parent_hash` is set to a zero-length octet string.
 Otherwise `parent_hash` is the Parent Hash of P's parent with P's sibling as the
 co-path child.
 
-Finally, `original_child_resolution` is the array of `HPKEPublicKey` values of the
-nodes in the resolution of S but with the `unmerged_leaves` of P omitted. For
-example, in the ratchet tree depicted in {{resolution-example}} the
-`ParentHashInput` of node 5 with co-path child 4 would contain an empty
-`original_child_resolution` since 4's resolution includes only itself but 4 is also
-an unmerged leaf of 5. Meanwhile, the `ParentHashInput` of node 5 with co-path child
-6 has an array with one element in it: the HPKE public key of 6.
+Finally, `original_sibling_tree_hash` is the original tree hash of S. The
+original tree hash corresponds to the tree hash of S the last time P was
+updated. It can be computed as the tree hash of S modified the following way:
+
+* reset the leaves in P.unmerged_leaves to blanks
+* remove P.unmerged_leaves from all unmerged_leaves lists
+
+For example, in the following tree:
+
+~~~~~
+    ABCD[C]
+    __|__
+   /     \
+  AB      CD[C]
+ / \     / \
+A   B   C   D
+~~~~~
+
+With P = ABCD and S = CD, `original_sibling_tree_hash` is the tree hash of the
+following tree:
+
+~~~~~
+  CD
+ / \
+_   D
+~~~~~
+
+Because ABCD.unmerged_leaves = [C], C is removed from CD.unmerged_leaves and C is replaced with a blank leaf.
 
 ### Using Parent Hashes
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1414,6 +1414,7 @@ updated. It can be computed as the tree hash of S modified the following way:
 
 * reset the leaves in P.unmerged_leaves to blanks
 * remove P.unmerged_leaves from all unmerged_leaves lists
+* truncate the tree as described in {{remove}}
 
 For example, in the following tree:
 
@@ -1424,7 +1425,7 @@ For example, in the following tree:
       U               Y [F, H]
     __|__           __|__
    /     \         /     \
-  T       V       X [F]   Z [H]
+  T       V       X [F]   _
  / \     / \     / \     / \
 A   B   C   D   E   F   G   H
 ~~~~~
@@ -1436,12 +1437,14 @@ following tree:
       Y [F]
     __|__
    /     \
-  X [F]   Z
- / \     / \
-E   F   G   _
+  X [F]  |
+ / \     |
+E   F    G
 ~~~~~
 
-Because W.unmerged_leaves = [H], H is removed from Y.unmerged_leaves and Z.unmerged_leaves, then H is replaced with a blank leaf.
+Because `W.unmerged_leaves = [H]`, H is removed from `Y.unmerged_leaves`,
+then H is replaced with a blank leaf, then the tree is truncated removing the
+last two nodes.
 
 ### Using Parent Hashes
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2037,7 +2037,20 @@ the following way:
 * reset the leaves in P.unmerged_leaves to blanks
 * remove P.unmerged_leaves from all unmerged_leaves lists
 * truncate the ratchet tree as described in {{remove}}
+Note that no recomputation is needed if the tree hash of S is unchanged since
+the last time P was updated.  This is the case for computing or processing a
+Commit whose UpdatePath traverses P, since the Commit itself resets P.  (In
+other words, it is only necessary to recompute the original sibling tree hash
+when validating group's tree on joining.) More generally, if none of the entries
+in `P.unmerged_leaves` is in the subtree under S (and thus no nodes were truncated),
+then the original tree hash at S is the tree hash of S in the current tree.
 
+If it is necessary to recompute the original tree hash of a node, the efficiency
+of recomputation can be improved by caching intermediate tree hashes, to avoid
+recomputing over the subtree when the subtree is included in multiple parent
+hashes.  A subtree hash can be reused as long as the intersection of the
+parent's unmerged leaves with the subtree is the same as in the earlier
+computation.
 For example, in the following tree:
 
 ~~~~~

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2037,20 +2037,7 @@ the following way:
 * reset the leaves in P.unmerged_leaves to blanks
 * remove P.unmerged_leaves from all unmerged_leaves lists
 * truncate the ratchet tree as described in {{remove}}
-Note that no recomputation is needed if the tree hash of S is unchanged since
-the last time P was updated.  This is the case for computing or processing a
-Commit whose UpdatePath traverses P, since the Commit itself resets P.  (In
-other words, it is only necessary to recompute the original sibling tree hash
-when validating group's tree on joining.) More generally, if none of the entries
-in `P.unmerged_leaves` is in the subtree under S (and thus no nodes were truncated),
-then the original tree hash at S is the tree hash of S in the current tree.
 
-If it is necessary to recompute the original tree hash of a node, the efficiency
-of recomputation can be improved by caching intermediate tree hashes, to avoid
-recomputing over the subtree when the subtree is included in multiple parent
-hashes.  A subtree hash can be reused as long as the intersection of the
-parent's unmerged leaves with the subtree is the same as in the earlier
-computation.
 For example, in the following tree:
 
 ~~~~~
@@ -2095,6 +2082,21 @@ A   B   C   _
 
 This time we have 4 leaf nodes because the truncation of the ratchet tree didn't
 remove the last leaf.
+
+Note that no recomputation is needed if the tree hash of S is unchanged since
+the last time P was updated.  This is the case for computing or processing a
+Commit whose UpdatePath traverses P, since the Commit itself resets P.  (In
+other words, it is only necessary to recompute the original sibling tree hash
+when validating group's tree on joining.) More generally, if none of the entries
+in `P.unmerged_leaves` is in the subtree under S (and thus no nodes were truncated),
+then the original tree hash at S is the tree hash of S in the current tree.
+
+If it is necessary to recompute the original tree hash of a node, the efficiency
+of recomputation can be improved by caching intermediate tree hashes, to avoid
+recomputing over the subtree when the subtree is included in multiple parent
+hashes.  A subtree hash can be reused as long as the intersection of the
+parent's unmerged leaves with the subtree is the same as in the earlier
+computation.
 
 ### Using Parent Hashes
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2031,22 +2031,23 @@ co-path child.
 
 Finally, `original_sibling_tree_hash` is the original tree hash of S. The
 original tree hash corresponds to the tree hash of S the last time P was
-updated. It can be computed as the tree hash of S modified the following way:
+updated. It can be computed as the tree hash of S in the ratchet tree modified
+the following way:
 
 * reset the leaves in P.unmerged_leaves to blanks
 * remove P.unmerged_leaves from all unmerged_leaves lists
-* truncate the tree as described in {{remove}}
+* truncate the ratchet tree as described in {{remove}}
 
 For example, in the following tree:
 
 ~~~~~
-              W [H]
+              W [D, H]
         ______|_____
        /             \
-      U               Y [F, H]
+      U [D]           Y [F, H]
     __|__           __|__
    /     \         /     \
-  T       V       X [F]   _
+  T       _       X [F]   _
  / \     / \     / \     / \
 A   B   C   D   E   F   G   H
 ~~~~~
@@ -2066,6 +2067,21 @@ E   F    G
 Because `W.unmerged_leaves = [H]`, H is removed from `Y.unmerged_leaves`,
 then H is replaced with a blank leaf, then the tree is truncated removing the
 last two nodes.
+
+With P = W and S = U, `original_sibling_tree_hash` is the tree hash of the
+following tree:
+
+~~~~~
+      U
+    __|__
+   /     \
+  T       _
+ / \     / \
+A   B   C   _
+~~~~~
+
+This time we have 4 leaf nodes because the truncation of the ratchet tree didn't
+remove the last leaf.
 
 ### Using Parent Hashes
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1225,24 +1225,30 @@ updated. It can be computed as the tree hash of S modified the following way:
 For example, in the following tree:
 
 ~~~~~
-    ABCD[C]
-    __|__
-   /     \
-  AB      CD[C]
- / \     / \
-A   B   C   D
+              W [H]
+        ______|_____
+       /             \
+      U               Y [F, H]
+    __|__           __|__
+   /     \         /     \
+  T       V       X [F]   Z [H]
+ / \     / \     / \     / \
+A   B   C   D   E   F   G   H
 ~~~~~
 
-With P = ABCD and S = CD, `original_sibling_tree_hash` is the tree hash of the
+With P = W and S = Y, `original_sibling_tree_hash` is the tree hash of the
 following tree:
 
 ~~~~~
-  CD
- / \
-_   D
+      Y [F]
+    __|__
+   /     \
+  X [F]   Z
+ / \     / \
+E   F   G   _
 ~~~~~
 
-Because ABCD.unmerged_leaves = [C], C is removed from CD.unmerged_leaves and C is replaced with a blank leaf.
+Because W.unmerged_leaves = [H], H is removed from Y.unmerged_leaves and Z.unmerged_leaves, then H is replaced with a blank leaf.
 
 ### Using Parent Hashes
 


### PR DESCRIPTION
Our proposal
============

The parent hash construction currently authenticates only the public keys in the ratchet tree and does not protect other tree contents, notably the credentials at the leaves.
Consequently, a malicious member can tamper with the credentials before sending a Welcome package to a new member, even if it cannot tamper with the public keys.

Instead of using the tree resolution in the parent hash computation, we propose to use the tree hash.

The last time this was discussed on the list, it was agreed that it would be better to use tree hashes from a security point of view, but it was felt that complexity-wise that the recipient of a Welcome message would have to do O(n^2) work.
A more thorough analysis shows that processing a Welcome message can be done in O(n*log(log(n))).
The result is that each signature captures the full tree contents including leaf credentials, which provides better authentication guarantees for member identities.

Efficient algorithm to process a Commit
=======================================

When processing Commits, the implementation can store the tree hashes of every subtree.
That way, with n being the number of leaves, you can process each proposal in O(log(n)) and each UpdatePath in O(log(n)).
Then you can check the parent hash when processing a Commit in O(p*log(n)) where p is the number of proposals.

Efficient (enough) algorithm to process a Welcome
=================================================

When processing a Welcome message, we need to do the parent hash verification procedure.
To do it with the new parent hash, we need to compute tree hashes of subtrees at the last time they were updated.
This can be done using the following modified tree hash:

    OldTreeHash(leaf, excluded_leaves) = Hash(leaf) if leaf not in excluded_leaves
    OldTreeHash(leaf, excluded_leaves) = Hash(blank leaf) if leaf in excluded_leaves
    OldTreeHash(node, excluded_leaves) = Hash(node.content | OldTreeHash(node.left, left_excluded_leaves) | OldTreeHash(node.right, right_excluded_leaves))
    where left_excluded_leaves = leaves that are in excluded_leaves and in node.left (same for right_excluded_leaves).
    and `excluded_leaves` are removed from `node.content.unmerged_leaves`.

Then we can compute the parent hash for a node `N` with child `C` and sibling `S` using `OldTreeHash(S, N.content.unmerged_leaves)`: this old tree hash don't change when Adds are applied to the tree.

In the next paragraph, we will see that we can compute the parent hash for every node in `O(n*log(n))`.

Let `h` be the height of the tree (so `h = log(n)`). There are `O(2^{h-i})` nodes at height `i`, and computing the parent hash for a node at height `i` is done in `O(2^i)`.
Hence, the complexity for the parent hash verification procedure is:

      \sum_{i=1}^h O(2^i 2^{h-i})
    = \sum_{i=1}^h O(2^h)
    = O(h 2^h)
And since `h = log(n)`, the complexity is `O(n*log(n))`.

Efficient algorithm to process a Welcome
========================================

Imagine we have the following tree:

                  W
            ______|______
           /             \
          U               Y [E, G]
        __|__           __|__
       /     \         /     \
      T       V       X [E]   Z [G, H]
     / \     / \     / \     / \
    A   B   C   D   E   F   G   H

For each node `N`, `OldTreeHash(N, excluded_leaves)` will be called with different values for `excluded_leaves`.

For example, if the sibling is always the right child, then:
- `OldTreeHash(H, .)` will be called with 1 time with `. = [H]` (when computing the parent hash of `Z`) and 2 times with `. = []` (when computing the parent hash of `Y` and `W`)
- `OldTreeHash(Z, .)` will be called with 1 time with `. = [G]` (when computing the parent hash of `Y`) and 1 time with `. = []` (when computing the parent hash of `W`)

If the sibling is always the left child, then:
- `OldTreeHash(A, .)` will be called 3 times with `. = []` (when computing the parent hash of `T`, `U`, `W`)
- `OldTreeHash(T, .)` will be called 2 times with `. = []` (when computing the parent hash of `U`, `W`)

We can see that some values are computed several times, which means that the whole computation could be sped up using memoization.

To estimate the speedup, we will estimate with how many values for `excluded_leaves` is called `OldTreeHash(N, .)` for each node `N`. Summing up these values will give a complexity, which will be `O(n*log(log(n)))`.

Let `node.parent[k]` be the `k`th parent of `node`, and `node.leaves` be the set of leaves in the subtree rooted at `node`.
Then, each call of `OldTreeHash(node, excluded_leaves)` will have `excluded_leaves = Intersection(node.parent[k].unmerged_leaves, node.leaves)` for some `k`.
Let's note this set `excluded_leaves_k`.
The tree has the invariant that if `i <= j` then `excluded_leaves_j` is a subset of `excluded_leaves_i` (i.e. the sets `excluded_leaves_k` are decreasing).

Let d be the depth of `node` (with the root being at depth 1). Then, the set `excluded_leaves_set := {excluded_leaves_1, ..., excluded_leaves_{d-1}}` corresponds to the values for `excluded_leaves` in the calls to `OldTreeHash(N, .)`.

First bound: `|excluded_leaves_set| <= d-1 <= d` because it is defined using `d-1` values.
Second bound: `|excluded_leaves_set| <= 2^{h-d}+1` because `|excluded_leaves_0| <= 2^{h-d}` and the sets `excluded_leaves_k` are decreasing.
Therefore: for a node at depth d, `|excluded_leaves_set| <= min(d, 2^{h-d}+1)`

The complexity to do the parent hash verification procedure is therefore in `O(sum_{i=1}^h 2^i min(i, 2^{h-i}+1))`.

Let's estimate this complexity more explicitly:

       sum_{i=1}^h 2^i min(i, 2^{h-i}+1)
    <= (sum_{i=1}^t i 2^i) + (sum_{i=t+1}^h 2^i (2^{h-i}+1)) [for all t]
    =  (2 (t-1) 2^t + 2) + ((h-t) 2^h + 2^{h+1} - 2^{t+1}) [for all t]

For the first inequality, we split the sum in two parts and use `min(i, 2^{h-i}+1) <= i` in the left part and `min(i, 2^{h-i}+1) <= 2^{h-i}+1` in the right part.
For the second equality, it can be derived using the formula for geometric sum.

If we take `t = h - log(h)`, we can compute that the left part is `O(2^h)` and the right part is `O(log(h)*2^h)`.

Therefore, the parent hash verification procedure complexity is `O(log(h)*2^h) = O(n*log(log(n)))`.

One might say that adding memoization has a cost and isn't in O(1), but here it is: using the fact that `excluded_leaves_k` are decreasing, if you process the tree in a bottom-up or top-down way, you only have to compare the length of the current `excluded_leaves` to the length of the previous one, and it tells you if you need to recompute the tree hash.

The current parent hash is not super fast
=========================================

In the worst case, if most internal nodes are blank, then computing the parent hash for a node is in O(size of its subtree), which give an O(n*log(n)) complexity as we saw in the section about the naive algorithm.

When processing a Commit, if most of the internal nodes are blank, then computing the new parent hashes is in O(n) which is quite slow.