### PR TITLE
Refactor Group Joining and fix External Inits

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -3486,7 +3486,7 @@ places:
 
 * In KeyPackages, to describe client capabilities and aspects of their
   participation in the group (once in the ratchet tree)
-* In the Welcome message, to tell new members of a group what parameters are
+* In the GroupInfo, to tell new members of a group what parameters are
   being used by the group, and to provide any additional details required to
   join the group
 * In the GroupContext object, to ensure that all members of the group have the

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -3134,7 +3134,6 @@ struct {
     Extension group_context_extensions<0..2^32-1>;
     Extension other_extensions<0..2^32-1>;
     MAC confirmation_tag;
-    optional<HPKEPublicKey> external_pub;
     KeyPackageRef signer;
 } GroupInfoTBS;
 ~~~

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -3114,7 +3114,6 @@ struct {
     Extension group_context_extensions<0..2^32-1>;
     Extension other_extensions<0..2^32-1>;
     MAC confirmation_tag;
-    optional<HPKEPublicKey> external_pub;
     KeyPackageRef signer;
     opaque signature<0..2^16-1>;
 } GroupInfo;
@@ -3140,9 +3139,6 @@ struct {
 } GroupInfoTBS;
 ~~~
 
-The `external_pub` public key is only required for External Commits and can be
-ommitted if External Commits are not allowed due to an application-level policy.
-
 #### Joining via External Commits
 
 External Commits are a mechanism for new members (external parties that want to
@@ -3166,7 +3162,13 @@ following information for the group's current epoch:
 * external public key
 
 Thus to join a group via an External Commit, a new member needs a GroupInfo with
-an `external_pub` present.
+an `ExternalPub` Extension present in `other_extensions`.
+
+~~~~~
+struct {
+    HPKEPublicKey external_pub;
+} ExternalPub;
+~~~~~
 
 Note that the `tree_hash` field is used the same way as in the Welcome message.
 The full tree can be included via the `ratchet_tree` extension
@@ -3961,6 +3963,7 @@ Initial contents:
 | 0x0004           | parent_hash              | KP         | Y           | RFC XXXX  |
 | 0x0005           | ratchet_tree             | GI         | Y           | RFC XXXX  |
 | 0x0006           | required_capabilities    | GC         | Y           | RFC XXXX  |
+| 0x0007           | external_pub             | GI         | Y           | RFC XXXX  |
 | 0xff00  - 0xffff | Reserved for Private Use | N/A        | N/A         | RFC XXXX  |
 
 ## MLS Proposal Types


### PR DESCRIPTION
This PR refactors the two sections on Group Joining (via Welcome and via External Init) by changing the `GroupInfo` struct that can be used for both cases. The `external_pub` used in the course of an External Init is added as an optional field. This PR also:

- removes the redundant ProtocolVersion in the GroupInfo
- adds a GroupInfoTBS struct to follow the convention of specifying a TBS struct for signed messages
- implicitly, the `confirmed_transcript_hash` and `confirmation_tag` is now used for external inits instead of the `interim_transcript_hash`, which was not sufficient to create a valid commit