### PR TITLE
Fix typo in EncryptedGroupSecrets

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -3256,7 +3256,7 @@ struct {
 } GroupSecrets;
 
 struct {
-  KeyPackageRef new_member<1..255>;
+  KeyPackageRef new_member;
   HPKECiphertext encrypted_group_secrets;
 } EncryptedGroupSecrets;
 


### PR DESCRIPTION
This PR fixes a typo in `EncryptedGroupSecrets` introduced by PR #491 .