### PR TITLE
Domain separation for KeyPackage and Proposal references

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1175,7 +1175,8 @@ to Proposals they cover.  These identifiers are computed as follows:
 ~~~~~
 opaque HashReference[16];
 
-MakeHashRef(value) = KDF.expand(KDF.extract("", value), "MLS 1.0 ref", 16)
+MakeKeyPackageRef(value) = KDF.expand(KDF.extract("", value), "MLS 1.0 KeyPackage Reference", 16)
+MakeProposalRef(value) = KDF.expand(KDF.extract("", value), "MLS 1.0 Proposal Reference", 16)
 
 HashReference KeyPackageRef;
 HashReference ProposalRef;

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1175,8 +1175,11 @@ to Proposals they cover.  These identifiers are computed as follows:
 ~~~~~
 opaque HashReference[16];
 
-MakeKeyPackageRef(value) = KDF.expand(KDF.extract("", value), "MLS 1.0 KeyPackage Reference", 16)
-MakeProposalRef(value) = KDF.expand(KDF.extract("", value), "MLS 1.0 Proposal Reference", 16)
+MakeKeyPackageRef(value) = KDF.expand(
+  KDF.extract("", value), "MLS 1.0 KeyPackage Reference", 16)
+
+MakeProposalRef(value) = KDF.expand(
+  KDF.extract("", value), "MLS 1.0 Proposal Reference", 16)
 
 HashReference KeyPackageRef;
 HashReference ProposalRef;


### PR DESCRIPTION
It doesn't seem super critical, but I think right now there could be a collision between references to Update/Add proposals and KeyPackages. Also, it's essentially free and it just feels wrong not to have proper domain separation for these values 😬.