### PR TITLE
Split the Group State section into Group Context and Transcript Hashes

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2046,7 +2046,16 @@ The following general rules apply:
 * The `extensions` field changes when a GroupContextExtensions proposal is
   committed.
 
-The `confirmed_transcript_hash` is updated with an MLSPlaintext in two steps:
+## Transcript Hashes
+
+The transcript hashes computed in MLS represent a running hash over all Proposal
+and Commit messages that have ever been sent in a group.  Commit messages are
+included directly. Proposal messages are indirectly included via the Commit that
+applied them. Both types of message are included by hashing the MLSPlaintext
+in which they were sent.
+
+The `confirmed_transcript_hash` is updated with an MLSPlaintext containing a
+Commit in two steps:
 
 ~~~~~
 struct {


### PR DESCRIPTION
This is the last of the reorg PRs.  Does what it says in the title.

<img width="482" alt="image" src="https://user-images.githubusercontent.com/75597/151904958-f1b7530e-2ef0-4ed0-93dd-b9e9db6bfcfc.png">
