### PR TITLE
Add message/mls MIME type registration

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -3979,7 +3979,7 @@ and nonce for a certain amount of time to retain the ability to decrypt
 delayed or out of order messages, possibly still in transit while a
 decryption is being done.
 
-# Security Considerations {#security}
+# Security Considerations
 
 The security goals of MLS are described in {{?I-D.ietf-mls-architecture}}.
 We describe here how the protocol achieves its goals at a high level,

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -4367,7 +4367,10 @@ protocols (ex: HTTP {{!RFC7540}}) to convey MLS messages.
   Optional parameters: version
      version: The MLS protocol version expressed as a string 
      <major>.<minor>.  If omitted the version is "1.0", which
-     corresponds to MLS ProtocolVersion mls10.
+     corresponds to MLS ProtocolVersion mls10. If for some reason
+     the version number in the MIME type parameter differs from the
+     ProtocolVersion embedded in the protocol, the protocol takes
+     precedence.
 
   Encoding scheme: MLS messages are represented using the TLS
      presentation language [RFC8446]. Therefore MLS messages need to be

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -4358,7 +4358,7 @@ MLS DE, that MLS DE SHOULD defer to the judgment of the other MLS DEs.
 ## The "message/mls" MIME Type
 
 This document registers the "message/mls" MIME media type in order to allow other
-protocols (ex: HTTP {{!RFC7540}}) to convey MLS messages. 
+protocols (ex: HTTP {{!RFC7540}}) to convey MLS messages.
 
 ~~~~~
   Media type name: message
@@ -4366,13 +4366,13 @@ protocols (ex: HTTP {{!RFC7540}}) to convey MLS messages.
   Required parameters: none
   Optional parameters: none
 
-  Encoding scheme: MLS messages are represented using the TLS 
-     presentation language {{!RFC8446}}. Therefore MLS messages need to be
+  Encoding scheme: MLS messages are represented using the TLS
+     presentation language [RFC8446]. Therefore MLS messages need to be
      treated as binary data.
 
   Security considerations: MLS is an encrypted messaging layer designed to
-     be transmitted over arbitrary lower layer protocols. The security 
-     considerations in {{security}} apply.
+     be transmitted over arbitrary lower layer protocols. The security
+     considerations in this document (the MLS protocol) also apply.
 ~~~~~
 
 # Contributors

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -4364,7 +4364,10 @@ protocols (ex: HTTP {{!RFC7540}}) to convey MLS messages.
   Media type name: message
   Media subtype name: mls
   Required parameters: none
-  Optional parameters: none
+  Optional parameters: version
+     version: The MLS protocol version expressed as a string 
+     <major>.<minor>.  If omitted the version is "1.0", which
+     corresponds to MLS ProtocolVersion mls10.
 
   Encoding scheme: MLS messages are represented using the TLS
      presentation language [RFC8446]. Therefore MLS messages need to be

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -3979,7 +3979,7 @@ and nonce for a certain amount of time to retain the ability to decrypt
 delayed or out of order messages, possibly still in transit while a
 decryption is being done.
 
-# Security Considerations
+# Security Considerations {#security}
 
 The security goals of MLS are described in {{?I-D.ietf-mls-architecture}}.
 We describe here how the protocol achieves its goals at a high level,
@@ -4354,6 +4354,26 @@ specification, in order to enable broadly informed review of
 registration decisions. In cases where a registration decision could
 be perceived as creating a conflict of interest for a particular
 MLS DE, that MLS DE SHOULD defer to the judgment of the other MLS DEs.
+
+## The "message/mls" MIME Type
+
+This document registers the "message/mls" MIME media type in order to allow other
+protocols (ex: HTTP {{!RFC7540}}) to convey MLS messages. 
+
+~~~~~
+  Media type name: message
+  Media subtype name: mls
+  Required parameters: none
+  Optional parameters: none
+
+  Encoding scheme: MLS messages are represented using the TLS 
+     presentation language {{!RFC8446}}. Therefore MLS messages need to be
+     treated as binary data.
+
+  Security considerations: MLS is an encrypted messaging layer designed to
+     be transmitted over arbitrary lower layer protocols. The security 
+     considerations in {{security}} apply.
+~~~~~
 
 # Contributors
 


### PR DESCRIPTION
This is a minimal section for MIME type registration of message/mls. 

It assumes that PR #523 include wire_format in all MLS messages (making a format parameter unnecessary),
and that all messages have the MLS version number encoded (making a version parameter unnecessary).

These parameters can be added if needed.