### PR TITLE
Add a simple ProofCredential alternative to Certificate.

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1218,6 +1218,7 @@ uint16 CredentialType;
 
 struct {
     opaque identity<V>;
+    opaque extra_data<V>;
     SignatureScheme signature_scheme;
     opaque signature_key<V>;
 } BasicCredential;
@@ -1227,6 +1228,12 @@ struct {
 } Certificate;
 
 struct {
+  opaque authority_id<0..255>;
+  BasicCredential credential;
+  opaque proof<0..2^16-1>;
+} ProofCredential;
+
+struct {
     CredentialType credential_type;
     select (Credential.credential_type) {
         case basic:
@@ -1234,6 +1241,9 @@ struct {
 
         case x509:
             Certificate chain<V>;
+
+        case proof:
+            ProofCredential;
     };
 } Credential;
 ~~~~~
@@ -1245,7 +1255,9 @@ ratchet tree or the KeyPackage ciphersuite for a credential in a KeyPackage
 object.  For ciphersuites using Ed25519 or Ed448 signature schemes, the public
 key is in the format specified {{?RFC8032}}.  For ciphersuites using ECDSA with
 the NIST curves P-256 or P-521, the public key is the output of the uncompressed
-Elliptic-Curve-Point-to-Octet-String conversion according to {{SECG}}.
+Elliptic-Curve-Point-to-Octet-String conversion according to {{SECG}}. The
+`extra_data` field may contain any additional application-specific data about
+the identity.
 
 For an X.509 credential, each entry in the chain represents a single DER-encoded
 X.509 certificate. The chain is ordered such that the first entry (chain[0])
@@ -1253,6 +1265,15 @@ is the end-entity certificate and each subsequent certificate in the chain
 MUST be the issuer of the previous certificate. The algorithm for the
 `public_key` in the end-entity certificate MUST match the relevant
 ciphersuite.
+
+A ProofCredential wraps a BasicCredential with some `proof` that the
+BasicCredential is valid from an authority specified by `authority_id`. Clients
+are pre-configured to recognize different authorities and the method of
+verifying the attached proof varies. In the simplest case, `proof` would contain
+a signature over the BasicCredential from a public key identified
+by `authority_id`. However, `proof` could also contain more sophisticated and
+structured data like an attestation from secure hardware, or an entry from a Key
+Transparency tree.
 
 The signatures used in this document are encoded as specified in {{!RFC8446}}.
 In particular, ECDSA signatures are DER-encoded and EdDSA signatures are defined
@@ -4612,6 +4633,7 @@ Initial contents:
 | 0x0000           | RESERVED                 | N/A         | RFC XXXX  |
 | 0x0001           | basic                    | Y           | RFC XXXX  |
 | 0x0002           | x509                     | Y           | RFC XXXX  |
+| 0x0003           | proof                    | Y           | RFC XXXX  |
 | 0xff00  - 0xffff | Reserved for Private Use | N/A         | RFC XXXX  |
 
 ## MLS Designated Expert Pool {#de}


### PR DESCRIPTION
- Adds an `extra_data` field to BasicCredential to hold application-specific data about a user (examples: link to avatar, information about device)
- Adds a ProofCredential to cover a lot of the cases we're currently missing, particularly:
  - credentials that are just BasicCredential signed with a fixed public key
  - credentials that are authenticated by a system like Key Transparency
  - credentials authenticated by secure hardware