### PR TITLE
Clean up the description of tree evolution.

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1512,43 +1512,36 @@ describe the content of the tree and the required operations.
 
 ## Ratchet Tree Evolution
 
-A member of an MLS group advances the key schedule to provide forward secrecy
-and post-compromise security by providing the group with fresh key material to
-be added into the group's shared secret.
-To do so, one member of the group generates fresh key
-material, applies it to their local tree state, and then sends this key material
-to other members in the group via an UpdatePath message (see {{update-paths}}) .
-All other group members then apply the key material in the UpdatePath to their
-own local tree state to derive the group's now-updated shared secret.
+Updating paths heals the ratchet tree, which in turn allows to heal the group key
+In order to provide forward secrecy and post-compromise security, whenever a
+member initiates an epoch change (i.e., commits; see {{commit}}), they refresh
+all HPKE secret keys in the ratchet tree that they know, that is, the secret
+keys of all nodes on their direct path.
 
-To begin, the generator of the UpdatePath updates its leaf
-KeyPackage and its direct path to the root with new secret values.  The
-HPKE leaf public key within the KeyPackage MUST be derived from a freshly
-generated HPKE secret key to provide post-compromise security.
+The member generates the fresh key pairs using the following procedure. The
+procedure is designed in a way that allows to efficiently communicate the fresh
+secret keys to other group members, as described in {{update-paths}}. 
 
-The generator of the UpdatePath starts by sampling a fresh random value called
-"leaf_secret", and uses the leaf_secret to generate their leaf HPKE key pair
-(see {{key-packages}}) and to seed a sequence of "path secrets", one for each
-ancestor of its leaf. In this setting,
-path_secret\[0\] refers to the leaf's parent,
-path_secret\[1\] to the parent's parent, and so on. At each step, the path
-secret is used to derive a new secret value for the corresponding
-node, from which the node's key pair is derived.
+* Generate a fresh HPKE key pair for the leaf.
+* Sample a fresh random value `leaf_secret`.
+* Compute the following sequence of path secrets, one for each node on the
+leaf's filtered direct path ordered from the node closest to the leaf to the
+root.
 
 ~~~~~
-leaf_node_secret = DeriveSecret(leaf_secret, "node")
 path_secret[0] = DeriveSecret(leaf_secret, "path")
-
 path_secret[n] = DeriveSecret(path_secret[n-1], "path")
-node_secret[n] = DeriveSecret(path_secret[n], "node")
+~~~~~
 
-leaf_priv, leaf_pub = KEM.DeriveKeyPair(leaf_node_secret)
+* For each `n`, compute the new HPKE key pair of the `n`-th node on the leaf's
+filtered direct path as follows:
+
+~~~~~
 node_priv[n], node_pub[n] = KEM.DeriveKeyPair(node_secret[n])
 ~~~~~
 
-The node secret is derived as a temporary intermediate secret so that each
-secret is only used with one algorithm: The path secret is used as an input to
-DeriveSecret and the node secret is used as an input to DeriveKeyPair.
+After performing these operations, the generator of the UpdatePath MUST
+delete the `leaf_secret`.
 
 For example, suppose there is a group with four members, with C an unmerged leaf
 at node 5:
@@ -1596,9 +1589,6 @@ np[0] -> X'      Z[C]
 
        0 1 2 3 4 5 6
 ~~~~~
-
-After performing these operations, the generator of the UpdatePath MUST
-delete the leaf_secret.
 
 ## Adding and Removing Leaves
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1504,7 +1504,7 @@ member of the group.
 # Ratchet Tree Operations
 
 The ratchet tree for an epoch describes the membership of a group in that epoch,
-providing public-key encryption keys that can be used to encrypt to subsets of
+providing public-key encryption (HPKE) keys that can be used to encrypt to subsets of
 the group as well as information to authenticate the members.  In order to
 reflect changes to the membership of the group from one epoch to the next,
 corresponding changes are made to the ratchet tree.  In this section, we
@@ -1512,43 +1512,38 @@ describe the content of the tree and the required operations.
 
 ## Ratchet Tree Evolution
 
-A member of an MLS group advances the key schedule to provide forward secrecy
-and post-compromise security by providing the group with fresh key material to
-be added into the group's shared secret.
-To do so, one member of the group generates fresh key
-material, applies it to their local tree state, and then sends this key material
-to other members in the group via an UpdatePath message (see {{update-paths}}) .
-All other group members then apply the key material in the UpdatePath to their
-own local tree state to derive the group's now-updated shared secret.
+In order to provide forward secrecy and post-compromise security, whenever a
+member initiates an epoch change (i.e., commits; see {{commit}}), they refresh
+all HPKE key pairs in the ratchet tree for which they know the secret keys.
+More precisely, they refresh the key pairs of their leaf and of all nodes on
+their leaf's direct path.
 
-To begin, the generator of the UpdatePath updates its leaf
-KeyPackage and its direct path to the root with new secret values.  The
-HPKE leaf public key within the KeyPackage MUST be derived from a freshly
-generated HPKE secret key to provide post-compromise security.
+The member initiating the epoch change generates the fresh key pairs using the
+following procedure. The procedure is designed in a way that allows to
+efficiently communicate the fresh secret keys to other group members, as
+described in {{update-paths}}. 
 
-The generator of the UpdatePath starts by sampling a fresh random value called
-"leaf_secret", and uses the leaf_secret to generate their leaf HPKE key pair
-(see {{key-packages}}) and to seed a sequence of "path secrets", one for each
-ancestor of its leaf. In this setting,
-path_secret\[0\] refers to the leaf's parent,
-path_secret\[1\] to the parent's parent, and so on. At each step, the path
-secret is used to derive a new secret value for the corresponding
-node, from which the node's key pair is derived.
+* Generate a fresh HPKE key pair for the leaf.
+* Generate a fresh random value `leaf_secret`.
+* Compute the following sequence of path secrets, one for each node on the
+leaf's direct path. In this context, `path_secret[0]` is computed for the
+leaf's parent, `path_secret[1]` is computed for the leaf's grandparent, etc.
 
 ~~~~~
-leaf_node_secret = DeriveSecret(leaf_secret, "node")
 path_secret[0] = DeriveSecret(leaf_secret, "path")
-
 path_secret[n] = DeriveSecret(path_secret[n-1], "path")
-node_secret[n] = DeriveSecret(path_secret[n], "node")
+~~~~~
 
-leaf_priv, leaf_pub = KEM.DeriveKeyPair(leaf_node_secret)
+* Compute the sequence of HPKE key pairs `(node_priv,node_pub)`, one for each
+node on the leaf's direct path, as follows.
+
+~~~~~
+node_secret[n] = DeriveSecret(path_secret[n], "node")
 node_priv[n], node_pub[n] = KEM.DeriveKeyPair(node_secret[n])
 ~~~~~
 
-The node secret is derived as a temporary intermediate secret so that each
-secret is only used with one algorithm: The path secret is used as an input to
-DeriveSecret and the node secret is used as an input to DeriveKeyPair.
+After performing these operations, the member initiating the epoch change MUST
+delete the `leaf_secret`.
 
 For example, suppose there is a group with four members, with C an unmerged leaf
 at node 5:
@@ -1596,9 +1591,6 @@ np[0] -> X'      Z[C]
 
        0 1 2 3 4 5 6
 ~~~~~
-
-After performing these operations, the generator of the UpdatePath MUST
-delete the leaf_secret.
 
 ## Adding and Removing Leaves
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1519,7 +1519,7 @@ More precisely, they refresh the key pairs of their leaf and of all nodes on
 their leaf's direct path.
 
 The member initiating the epoch change generates the fresh key pairs using the
-following procedure. The procedure is designed in a way that allows to
+following procedure. The procedure is designed in a way that allows group members to
 efficiently communicate the fresh secret keys to other group members, as
 described in {{update-paths}}. 
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1521,17 +1521,17 @@ their leaf's direct path.
 The member initiating the epoch change generates the fresh key pairs using the
 following procedure. The procedure is designed in a way that allows group members to
 efficiently communicate the fresh secret keys to other group members, as
-described in {{update-paths}}. 
+described in {{update-paths}}.
 
 * Generate a fresh HPKE key pair for the leaf.
 * Generate a sequence of path secrets, one for each node on the leaf's direct
-path as follows. Sample a fresh random value `path_secret[0]` and compute
-
+  path as follows. In this context, `path_secret[0]` is generated for the
+  leaf's parent, `path_secret[1]` is generated for the leaf's grandparent, etc.
+  
   ~~~~~
+  path_secret[0] is sampled at random
   path_secret[n] = DeriveSecret(path_secret[n-1], "path")
   ~~~~~
-In this context, `path_secret[0]` is generated for the leaf's parent,
-`path_secret[1]` is generated for the leaf's grandparent, etc.
 
 * Compute the sequence of HPKE key pairs `(node_priv,node_pub)`, one for each
 node on the leaf's direct path, as follows.

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1524,26 +1524,22 @@ efficiently communicate the fresh secret keys to other group members, as
 described in {{update-paths}}. 
 
 * Generate a fresh HPKE key pair for the leaf.
-* Generate a fresh random value `leaf_secret`.
-* Compute the following sequence of path secrets, one for each node on the
-leaf's direct path. In this context, `path_secret[0]` is computed for the
-leaf's parent, `path_secret[1]` is computed for the leaf's grandparent, etc.
+* Generate a sequence of path secrets, one for each node on the leaf's direct
+path as follows. Sample a fresh random value `path_secret[0]` and compute
 
-~~~~~
-path_secret[0] = DeriveSecret(leaf_secret, "path")
-path_secret[n] = DeriveSecret(path_secret[n-1], "path")
-~~~~~
+  ~~~~~
+  path_secret[n] = DeriveSecret(path_secret[n-1], "path")
+  ~~~~~
+In this context, `path_secret[0]` is generated for the leaf's parent,
+`path_secret[1]` is generated for the leaf's grandparent, etc.
 
 * Compute the sequence of HPKE key pairs `(node_priv,node_pub)`, one for each
 node on the leaf's direct path, as follows.
 
-~~~~~
-node_secret[n] = DeriveSecret(path_secret[n], "node")
-node_priv[n], node_pub[n] = KEM.DeriveKeyPair(node_secret[n])
-~~~~~
-
-After performing these operations, the member initiating the epoch change MUST
-delete the `leaf_secret`.
+  ~~~~~
+  node_secret[n] = DeriveSecret(path_secret[n], "node")
+  node_priv[n], node_pub[n] = KEM.DeriveKeyPair(node_secret[n])
+  ~~~~~
 
 For example, suppose there is a group with four members, with C an unmerged leaf
 at node 5:

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1512,36 +1512,43 @@ describe the content of the tree and the required operations.
 
 ## Ratchet Tree Evolution
 
-Updating paths heals the ratchet tree, which in turn allows to heal the group key
-In order to provide forward secrecy and post-compromise security, whenever a
-member initiates an epoch change (i.e., commits; see {{commit}}), they refresh
-all HPKE secret keys in the ratchet tree that they know, that is, the secret
-keys of all nodes on their direct path.
+A member of an MLS group advances the key schedule to provide forward secrecy
+and post-compromise security by providing the group with fresh key material to
+be added into the group's shared secret.
+To do so, one member of the group generates fresh key
+material, applies it to their local tree state, and then sends this key material
+to other members in the group via an UpdatePath message (see {{update-paths}}) .
+All other group members then apply the key material in the UpdatePath to their
+own local tree state to derive the group's now-updated shared secret.
 
-The member generates the fresh key pairs using the following procedure. The
-procedure is designed in a way that allows to efficiently communicate the fresh
-secret keys to other group members, as described in {{update-paths}}. 
+To begin, the generator of the UpdatePath updates its leaf
+KeyPackage and its direct path to the root with new secret values.  The
+HPKE leaf public key within the KeyPackage MUST be derived from a freshly
+generated HPKE secret key to provide post-compromise security.
 
-* Generate a fresh HPKE key pair for the leaf.
-* Sample a fresh random value `leaf_secret`.
-* Compute the following sequence of path secrets, one for each node on the
-leaf's filtered direct path ordered from the node closest to the leaf to the
-root.
+The generator of the UpdatePath starts by sampling a fresh random value called
+"leaf_secret", and uses the leaf_secret to generate their leaf HPKE key pair
+(see {{key-packages}}) and to seed a sequence of "path secrets", one for each
+ancestor of its leaf. In this setting,
+path_secret\[0\] refers to the leaf's parent,
+path_secret\[1\] to the parent's parent, and so on. At each step, the path
+secret is used to derive a new secret value for the corresponding
+node, from which the node's key pair is derived.
 
 ~~~~~
+leaf_node_secret = DeriveSecret(leaf_secret, "node")
 path_secret[0] = DeriveSecret(leaf_secret, "path")
+
 path_secret[n] = DeriveSecret(path_secret[n-1], "path")
-~~~~~
+node_secret[n] = DeriveSecret(path_secret[n], "node")
 
-* For each `n`, compute the new HPKE key pair of the `n`-th node on the leaf's
-filtered direct path as follows:
-
-~~~~~
+leaf_priv, leaf_pub = KEM.DeriveKeyPair(leaf_node_secret)
 node_priv[n], node_pub[n] = KEM.DeriveKeyPair(node_secret[n])
 ~~~~~
 
-After performing these operations, the generator of the UpdatePath MUST
-delete the `leaf_secret`.
+The node secret is derived as a temporary intermediate secret so that each
+secret is only used with one algorithm: The path secret is used as an input to
+DeriveSecret and the node secret is used as an input to DeriveKeyPair.
 
 For example, suppose there is a group with four members, with C an unmerged leaf
 at node 5:
@@ -1589,6 +1596,9 @@ np[0] -> X'      Z[C]
 
        0 1 2 3 4 5 6
 ~~~~~
+
+After performing these operations, the generator of the UpdatePath MUST
+delete the leaf_secret.
 
 ## Adding and Removing Leaves
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -941,26 +941,10 @@ the private key AB is known only to A and B.
 A particular instance of a ratchet tree is defined by the same parameters that
 define an instance of HPKE, namely:
 
-<<<<<<< HEAD
 * A Key Encapsulation Mechanism (KEM), including a `DeriveKeyPair` function that
   creates a key pair for the KEM from a symmetric secret
 * A Key Derivation Function (KDF), including `Extract` and `Expand` functions
 * An AEAD encryption scheme
-=======
-To begin, the generator of the UpdatePath updates its leaf
-KeyPackage and its direct path to the root with new secret values.  The
-HPKE leaf public key within the KeyPackage MUST be derived from a freshly
-generated HPKE secret key to provide post-compromise security.
-
-The generator of the UpdatePath starts by sampling a fresh random value called
-"leaf_secret", and uses the leaf_secret to generate their leaf HPKE key pair
-(see {{key-packages}}) and to seed a sequence of "path secrets", one for each
-ancestor of its leaf. In this setting,
-path_secret\[0\] refers to the leaf's parent,
-path_secret\[1\] to the parent's parent, and so on. At each step, the path
-secret is used to derive a new secret value for the corresponding
-node, from which the node's key pair is derived.
->>>>>>> 8aec514 (Revert "Restored aggressive truncation and introduced filtered direct paths to fix the parent hash.")
 
 Each node in a ratchet tree contains up to five values:
 
@@ -1060,134 +1044,6 @@ SignWithLabel(SignatureKey, Label, Content) =
 VerifyWithLabel(VerificationKey, Label, Content) =
     Signature.Verify(VerificationKey, SignContent)
 
-<<<<<<< HEAD
-=======
-Concrete algorithms for these operations on array-based and link-based trees are
-provided in {{array-based-trees}} and {{link-based-trees}}.  The concrete
-algorithms are non-normative.  An implementation MAY use any algorithm that
-produces the correct tree in its internal representation.
-
-## Synchronizing Views of the Tree
-
-After generating fresh key material and applying it to ratchet forward their
-local tree state as described in the prior section, the generator must broadcast
-this update to other members of the group in a Commit message, who
-apply it to keep their local views of the tree in
-sync with the sender's.  More specifically, when a member commits a change to
-the tree (e.g., to add or remove a member), it transmits an UpdatePath
-containing a set of public keys and encrypted path secrets
-for intermediate nodes in the direct path of its leaf. The
-other members of the group use these values to update
-their view of the tree, aligning their copy of the tree to the
-sender's.
-
-An UpdatePath contains
-the following information for each node in the direct path of the
-sender's leaf, including the root:
-
-* The public key for the node
-* Zero or more encrypted copies of the path secret corresponding to
-  the node
-
-The path secret value for a given node is encrypted for the subtree
-corresponding to the parent's non-updated child, that is, the child
-on the copath of the sender's leaf node.
-There is one encryption of the path secret to each public key in the resolution
-of the non-updated child.
-
-The recipient of an UpdatePath processes it with the following steps:
-
-1. Compute the updated path secrets.
-   * Identify a node in the direct path for which the local member
-     is in the subtree of the non-updated child.
-   * Identify a node in the resolution of the copath node for
-     which this node has a private key.
-   * Decrypt the path secret for the parent of the copath node using
-     the private key from the resolution node.
-   * Derive path secrets for ancestors of that node using the
-     algorithm described above.
-   * The recipient SHOULD verify that the received public keys agree
-     with the public keys derived from the new path_secret values.
-2. Merge the updated path secrets into the tree.
-   * For all updated nodes,
-     * Replace the public key for each node with the received public key.
-     * Set the list of unmerged leaves to the empty list.
-     * Store the updated hash of the node's parent (represented as a ParentNode
-       struct), going from root to leaf, so that each hash incorporates all the
-       nodes above it. The root node always has a zero-length hash for this
-       value.
-   * For nodes where a path secret was recovered in step 1,
-     compute and store the node's updated private key.
-
-For example, in order to communicate the example update described in
-the previous section, the sender would transmit the following
-values:
-
-| Public Key    | Ciphertext(s)                                           |
-|:--------------|:--------------------------------------------------------|
-| node_pub\[1\] | E(pk(Z), path_secret\[1\]), E(pk(C), path_secret\[1\])  |
-| node_pub\[0\] | E(pk(A), path_secret\[0\])                              |
-
-In this table, the value node_pub\[i\] represents the public key
-derived from node_secret\[i\], pk(X) represents the current public key
-of node X, and E(K, S) represents
-the public-key encryption of the path secret S to the
-public key K (using HPKE).
-
-After processing the update, each recipient MUST delete outdated key material,
-specifically:
-
-* The path secrets used to derive each updated node key pair.
-* Each outdated node key pair that was replaced by the update.
-
-
-# Cryptographic Objects
-
-## Ciphersuites
-
-Each MLS session uses a single ciphersuite that specifies the
-following primitives to be used in group key computations:
-
-* HPKE parameters:
-  * A Key Encapsulation Mechanism (KEM)
-  * A Key Derivation Function (KDF)
-  * An AEAD encryption algorithm
-* A hash algorithm
-* A MAC algorithm
-* A signature algorithm
-
-MLS uses HPKE for public-key encryption {{I-D.irtf-cfrg-hpke}}.  The
-`DeriveKeyPair` function associated to the KEM for the ciphersuite maps octet
-strings to HPKE key pairs.  As in HPKE, MLS assumes that an AEAD algorithm
-produces a single ciphertext output from AEAD encryption (aligning with
-{{?RFC5116}}), as opposed to a separate ciphertext and tag.
-
-Ciphersuites are represented with the CipherSuite type. HPKE public keys
-are opaque values in a format defined by the underlying
-protocol (see the Cryptographic Dependencies section of the HPKE specification for more
-information).
-
-~~~~~
-opaque HPKEPublicKey<1..2^16-1>;
-~~~~~
-
-The signature algorithm specified in the ciphersuite is the mandatory algorithm
-to be used for signatures in MLSPlaintext and the tree signatures.  It MUST be
-the same as the signature algorithm specified in the credential field of the
-KeyPackage objects in the leaves of the tree (including the InitKeys
-used to add new members).
-
-To disambiguate different signatures used in MLS, each signed value is prefixed
-by a label as shown below:
-
-~~~~~
-SignWithLabel(SignatureKey, Label, Content) =
-    Signature.Sign(SignatureKey, SignContent)
-
-VerifyWithLabel(VerificationKey, Label, Content) =
-    Signature.Verify(VerificationKey, SignContent)
-
->>>>>>> 8aec514 (Revert "Restored aggressive truncation and introduced filtered direct paths to fix the parent hash.")
 Where SignContent is specified as:
 
 struct {


### PR DESCRIPTION
Changes (apart from editorial):
* Remove the text about the key schedule. Reason: I found the text confusing, because updating paths provides FS and PCS for the HPKE keys in the ratchet tree, and not directly for the key schedule.
* Generate the leaf key pair simply as a fresh HPKE key pair, and not from the leaf_secret. I couldn't see any benefit of using the leaf_secret. I wonder if there is a good reason?