### PR TITLE
Preconfigured senders extension and removal of signature key indirection

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1490,7 +1490,9 @@ depending on the sender's `sender_type`:
   sender's `LeafNodeRef`
 * `external`: The signature key contained in the Credential at the index
   indicated by the `sender_index` in the `external_senders` group context
-  extension (see Section {{external-senders-extension}}).
+  extension (see Section {{external-senders-extension}}).  In this case, the
+  `content_type` of the message MUST NOT be `commit`, since only members
+  of the group or new joiners can send Commit messages.
 * `new_member`: The signature key depends on the `content_type`:
   * `proposal`: The signature key in the credential contained in KeyPackage in
     the Add proposal (see Section {{external-proposals}}).

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1378,7 +1378,7 @@ enum {
 enum {
     reserved(0),
     member(1),
-    preconfigured(2),
+    external(2),
     new_member(3),
     (255)
 } SenderType;
@@ -1388,8 +1388,8 @@ struct {
     switch (sender_type) {
         case member:
             LeafNodeRef member_ref;
-        case preconfigured:
-            u32 sender_id;
+        case external:
+            u32 sender_index;
         case new_member:
             struct{};
     }
@@ -1488,9 +1488,9 @@ depending on the sender's `sender_type`:
 
 * `member`: The signature key contained in the Credential at the leaf with the
   sender's `LeafNodeRef`
-* `preconfigured`: The signature key contained in the Credential at the index
-  indicated by the `sender_id` in the `preconfigured_senders` group context
-  extension (see Section {{preconfigured-senders-extension}}).
+* `external`: The signature key contained in the Credential at the index
+  indicated by the `sender_index` in the `external_senders` group context
+  extension (see Section {{external-senders-extension}}).
 * `new_member`: The signature key depends on the `content_type`:
   * `proposal`: The signature key in the credential contained in KeyPackage in
     the Add proposal (see Section {{external-proposals}}).
@@ -1507,7 +1507,7 @@ struct {
         case new_member:
             GroupContext context;
 
-        case preconfigured:
+        case external:
             struct{};
     }
 } MLSMessageContentTBS;
@@ -1533,7 +1533,7 @@ struct {
     select(MLSPlaintext.content.sender.sender_type) {
         case member:
             MAC membership_tag;
-        case preconfigured:
+        case external:
         case new_member:
             struct{};
     }
@@ -3421,10 +3421,10 @@ Add and Remove proposals can be constructed and sent to the group by a party
 that is outside the group.  For example, a Delivery Service might propose to
 remove a member of a group who has been inactive for a long time, or propose adding
 a newly-hired staff member to a group representing a real-world team.  Proposals
-originating outside the group are identified by a `preconfigured` or
+originating outside the group are identified by a `external` or
 `new_member` SenderType in MLSPlaintext.
 
-ReInit proposals can also be sent to the group by a `preconfigured` sender, for
+ReInit proposals can also be sent to the group by a `external` sender, for
 example to enforce a changed policy regarding MLS version or ciphersuite.
 
 The `new_member` SenderType is used for clients proposing that they themselves
@@ -3433,22 +3433,22 @@ MUST be Add. The MLSPlaintext MUST be signed with the private key corresponding
 to the KeyPackage in the Add message.  Recipients MUST verify that the
 MLSPlaintext carrying the Proposal message is validly signed with this key.
 
-The `preconfigured` SenderType is reserved for signers that are pre-provisioned
+The `external` SenderType is reserved for signers that are pre-provisioned
 to the clients within a group. It can only be used if the
-`preconfigured_senders` extension is present in the group's group context
+`external_senders` extension is present in the group's group context
 extensions.
 
 An external proposal MUST be sent as an MLSPlaintext object, since the sender
 will not have the keys necessary to construct an MLSCiphertext object.
 
-#### Preconfigured Senders Extension
+#### External Senders Extension
 
-The `preconfigured_senders` extension is a group context extension that contains
+The `external_senders` extension is a group context extension that contains
 credentials of senders that are permitted to send external proposals to the
 group.
 
 ~~~~~
-Credential preconfigured_senders<V>;
+Credential external_senders<V>;
 ~~~~~
 
 ## Commit

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -3433,15 +3433,13 @@ MUST be Add. The MLSPlaintext MUST be signed with the private key corresponding
 to the KeyPackage in the Add message.  Recipients MUST verify that the
 MLSPlaintext carrying the Proposal message is validly signed with this key.
 
-The `preconfigured` SenderType can only be used if the `preconfigured_senders`
-extension is present in the group's group context extensions. Recipients MUST
-verify that the MLSPlaintext carrying the Proposal message is validly signed
-with the signature key in the credential located at the index equal to the
-sender's `sender_id`.
+The `preconfigured` SenderType is reserved for signers that are pre-provisioned
+to the clients within a group. It can only be used if the
+`preconfigured_senders` extension is present in the group's group context
+extensions.
 
-An external proposal MUST be sent as an MLSPlaintext
-object, since the sender will not have the keys necessary to construct an
-MLSCiphertext object.
+An external proposal MUST be sent as an MLSPlaintext object, since the sender
+will not have the keys necessary to construct an MLSCiphertext object.
 
 #### Preconfigured Senders Extension
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1343,7 +1343,7 @@ struct {
     SenderType sender_type;
     switch (sender_type) {
         case member:        LeafNodeRef member;
-        case preconfigured: opaque sender_id<V>;
+        case preconfigured: u32 sender_id;
         case new_member:    struct{};
     }
 } Sender;
@@ -3385,18 +3385,25 @@ MUST be Add. The MLSPlaintext MUST be signed with the private key corresponding
 to the KeyPackage in the Add message.  Recipients MUST verify that the
 MLSPlaintext carrying the Proposal message is validly signed with this key.
 
-The `preconfigured` SenderType is reserved for signers that are pre-provisioned
-to the clients within a group.  If proposals with these sender IDs are to be
-accepted within a group, the members of the group MUST be provisioned by the
-application with a mapping between these IDs and authorized signing keys.
-Recipients MUST verify that the MLSPlaintext carrying the Proposal message is
-validly signed with the corresponding key. To ensure consistent handling of
-external proposals, the application MUST ensure that the members of a group
-have the same mapping and apply the same policies to external proposals.
+The `preconfigured` SenderType can only be used if the `preconfigured_senders`
+extension is present in the group's group context extensions. Recipients MUST
+verify that the MLSPlaintext carrying the Proposal message is validly signed
+with the signature key in the credential located at the index equal to the
+sender's `sender_id`.
 
 An external proposal MUST be sent as an MLSPlaintext
 object, since the sender will not have the keys necessary to construct an
 MLSCiphertext object.
+
+#### Preconfigured Senders Extension
+
+The `preconfigured_senders` extension is a group context extension that contains
+credentials of senders that are permitted to send external proposals to the
+group.
+
+~~~~~
+Credential preconfigured_senders<V>;
+~~~~~
 
 ## Commit
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1389,7 +1389,7 @@ struct {
         case member:
             LeafNodeRef member_ref;
         case external:
-            u32 sender_index;
+            uint32 sender_index;
         case new_member:
             struct{};
     }


### PR DESCRIPTION
This PR:
- consolidates instructions on which key should be used to compute (and verify) a signature on an MLS message depending on the sender type
- reverts #437 
- introduces a `preconfigured_senders` extension that ensures that group members agree on preconfigured signature keys, as discussed in #616 and on the mailing list

Fixes #616.

