### PR TITLE
Require init key and leaf key to be different

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2990,6 +2990,9 @@ The client verifies the validity of a KeyPackage using the following steps:
 * Verify that the signature on the KeyPackage is valid using the public key
   in `leaf_node.credential`.
 
+* Verify that the value of `leaf_node.public_key` is different from the value of
+  the `init_key` field.
+
 ## KeyPackage Identifiers
 
 Within MLS, a KeyPackage is identified by its hash (see, e.g.,


### PR DESCRIPTION
This change ensures that the "init" key pair associated to the key package is one-time-use, at least to the degree that KeyPackages are one-time-use.  The init key pair is used to encrypt/decrypt the Welcome message, then never again.

The main drawback is requiring the KeyPackage sender to generate an additional key pair, which requires more computation and more entropy.