### PR TITLE
Clean up code blocks

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -476,7 +476,7 @@ An optional value is encoded with a presence-signaling octet, followed by the
 value itself if present.  When decoding, a presence octet with a value other
 than 0 or 1 MUST be rejected as malformed.
 
-~~~
+~~~ tls
 struct {
     uint8 present;
     select (present) {
@@ -499,7 +499,7 @@ a variable-length integer encoding based on the one in Section 16 of
 encoding.) Instead of presenting min and max values, the vector description
 simply includes a `V`. For example:
 
-~~~
+~~~ tls
 struct {
     uint32 fixed<0..255>;
     opaque variable<V>;
@@ -534,7 +534,7 @@ decodes to 37.
 The following figure adapts the pseudocode provided in {{RFC9000}} to add a
 check for minimum-length encoding:
 
-~~~
+~~~ pseudocode
 ReadVarint(data):
   // The length of variable-length integers is encoded in the
   // first two bits of the first byte.
@@ -625,7 +625,7 @@ both Proposal/Commit messages as well as any application data.
 
 The cryptographic state at the core of MLS is divided into three areas of responsibility:
 
-~~~
+~~~ ascii-art
                            epoch_secret
                          _      |      _
 |\ Ratchet              /      ...      \                    Secret /|
@@ -707,18 +707,18 @@ MLSPlaintext or MLSCiphertext objects.
 Before the initialization of a group, clients publish KeyPackages to a directory
 provided by the Service Provider.
 
-~~~
+~~~ aasvg
                                                                Group
 A                B                C            Directory       Channel
 |                |                |                |              |
 | KeyPackageA    |                |                |              |
-|------------------------------------------------->|              |
++------------------------------------------------->|              |
 |                |                |                |              |
 |                | KeyPackageB    |                |              |
-|                |-------------------------------->|              |
+|                +-------------------------------->|              |
 |                |                |                |              |
 |                |                | KeyPackageC    |              |
-|                |                |--------------->|              |
+|                |                +--------------->|              |
 |                |                |                |              |
 ~~~
 {: title="Clients A, B, and C publish KeyPackages to the directory"}
@@ -735,36 +735,36 @@ Upon receiving the Welcome message, the new member will be able to read and send
 new messages to the group. However, messages sent before they were added to the
 group will not be accessible.
 
-~~~
+~~~ aasvg
                                                                Group
 A              B              C          Directory            Channel
 |              |              |              |                   |
 |         KeyPackageB, KeyPackageC           |                   |
-|<-------------------------------------------|                   |
+|<-------------------------------------------+                   |
 |              |              |              |                   |
 |              |              |              | Add(A->AB)        |
 |              |              |              | Commit(Add)       |
-|--------------------------------------------------------------->|
++--------------------------------------------------------------->|
 |              |              |              |                   |
 |  Welcome(B)  |              |              |                   |
-|------------->|              |              |                   |
++------------->|              |              |                   |
 |              |              |              |                   |
 |              |              |              | Add(A->AB)        |
 |              |              |              | Commit(Add)       |
-|<---------------------------------------------------------------|
+|<---------------------------------------------------------------+
 |              |              |              |                   |
 |              |              |              |                   |
 |              |              |              | Add(AB->ABC)      |
 |              |              |              | Commit(Add)       |
-|--------------------------------------------------------------->|
++--------------------------------------------------------------->|
 |              |              |              |                   |
 |              |  Welcome(C)  |              |                   |
-|---------------------------->|              |                   |
++---------------------------->|              |                   |
 |              |              |              |                   |
 |              |              |              | Add(AB->ABC)      |
 |              |              |              | Commit(Add)       |
-|<---------------------------------------------------------------|
-|              |<------------------------------------------------|
+|<---------------------------------------------------------------+
+|              |<------------------------------------------------+
 |              |              |              |                   |
 ~~~
 {: title="Client A creates a group with clients B and C"}
@@ -787,20 +787,20 @@ is active, and members that don't update should eventually be removed from the
 group. It's left to the application to determine an appropriate amount of time
 between Updates.
 
-~~~
+~~~ aasvg
                                                           Group
 A              B     ...      Z          Directory        Channel
 |              |              |              |              |
 |              | Update(B)    |              |              |
-|              |------------------------------------------->|
+|              +------------------------------------------->|
 | Commit(Upd)  |              |              |              |
-|---------------------------------------------------------->|
++---------------------------------------------------------->|
 |              |              |              |              |
 |              |              |              | Update(B)    |
 |              |              |              | Commit(Upd)  |
-|<----------------------------------------------------------|
-|              |<-------------------------------------------|
-|              |              |<----------------------------|
+|<----------------------------------------------------------+
+|              |<-------------------------------------------+
+|              |              |<----------------------------+
 |              |              |              |              |
 ~~~
 {: title="Client B proposes to update its key, and client A commits the
@@ -817,18 +817,18 @@ is actually allowed to evict other members; groups can
 enforce access control policies on top of these
 basic mechanism.
 
-~~~
+~~~ aasvg
                                                           Group
 A              B     ...      Z          Directory       Channel
 |              |              |              |              |
 |              |              | Remove(B)    |              |
 |              |              | Commit(Rem)  |              |
-|              |              |---------------------------->|
+|              |              +---------------------------->|
 |              |              |              |              |
 |              |              |              | Remove(B)    |
 |              |              |              | Commit(Rem)  |
-|<----------------------------------------------------------|
-|              |              |<----------------------------|
+|<----------------------------------------------------------+
+|              |              |<----------------------------+
 |              |              |              |              |
 ~~~
 {: title="Client Z removes client B from the group"}
@@ -849,7 +849,7 @@ different parameters. Branching starts a new group with a subset of the original
 group's participants (with no effect on the original group).  In both cases,
 the new group is linked to the old group via a resumption PSK.
 
-~~~
+~~~ ascii-art
 epoch_A_[n-1]
      |
      |
@@ -867,13 +867,7 @@ epoch_A_[n]           epoch_B_[0]
 {: title="Reinitializing a group" }
 
 
-~~~
-epoch_A_[n-1]
-     |
-     |
-     |<-- ReInit
-     |
-     V
+~~~ ascii-art
 epoch_A_[n]           epoch_B_[0]
      |                     |
      |  PSK(usage=branch)  |
@@ -890,13 +884,7 @@ from epoch `n` is injected into epoch `n+k`.  This demonstrates that the members
 of the group at epoch `n+k` were also members at epoch `n`, irrespective of any
 changes to these members' keys due to Updates or Commits.
 
-~~~
-epoch_A_[n-1]
-     |
-     |
-     |<-- ReInit
-     |
-     V
+~~~ ascii-art
 epoch_A_[n]
      |
      |  PSK(usage=application)
@@ -980,7 +968,7 @@ For example, in the below tree:
 * The direct path of C is (W, V, X)
 * The copath of C is (D, U, Z)
 
-~~~
+~~~ ascii-art
               X = root
         ______|______
        /             \
@@ -1053,7 +1041,7 @@ private keys of the tree held by each participant would be as follows, where `_`
 represents a blank node, `?` represents an unknown private key, and `pk(X)`
 represents the public key corresponding to the private key `X`:
 
-~~~
+~~~ ascii-art
          Public Tree
 ============================
             pk(ABCD)
@@ -1111,7 +1099,7 @@ For example, consider the following subtree, where the `_` character
 represents a blank node and unmerged leaves are indicated in square
 brackets:
 
-~~~
+~~~ ascii-art
        ...
        /
       _
@@ -1162,7 +1150,7 @@ are opaque values in a format defined by the underlying
 protocol (see the Cryptographic Dependencies section of the HPKE specification for more
 information).
 
-~~~
+~~~ tls
 opaque HPKEPublicKey<V>;
 ~~~
 
@@ -1175,7 +1163,7 @@ members).
 To disambiguate different signatures used in MLS, each signed value is prefixed
 by a label as shown below:
 
-~~~
+~~~ pseudocode
 SignWithLabel(SignatureKey, Label, Content) =
     Signature.Sign(SignatureKey, SignContent)
 
@@ -1201,9 +1189,15 @@ Some MLS messages refer to other MLS objects by hash.  For example, Welcome
 messages refer to KeyPackages for the members being welcomed, and Commits refer
 to Proposals they cover.  These identifiers are computed as follows:
 
-~~~
+~~~ tls
 opaque HashReference[16];
 
+HashReference KeyPackageRef;
+HashReference LeafNodeRef;
+HashReference ProposalRef;
+~~~
+
+~~~ pseudocode
 MakeKeyPackageRef(value) = KDF.expand(
   KDF.extract("", value), "MLS 1.0 KeyPackage Reference", 16)
 
@@ -1212,10 +1206,6 @@ MakeLeafNodeRef(value) = KDF.expand(
 
 MakeProposalRef(value) = KDF.expand(
   KDF.extract("", value), "MLS 1.0 Proposal Reference", 16)
-
-HashReference KeyPackageRef;
-HashReference LeafNodeRef;
-HashReference ProposalRef;
 ~~~
 
 For a KeyPackageRef, the `value` input is the encoded KeyPackage, and the
@@ -1254,7 +1244,7 @@ to verify the identity / signing key binding.
 Additionally, Credentials SHOULD specify the signature scheme corresponding to
 each contained public key.
 
-~~~
+~~~ tls
 // See RFC 8446 and the IANA TLS SignatureScheme registry
 uint16 SignatureScheme;
 
@@ -1360,7 +1350,7 @@ handshake messages, but MAY transmit handshake messages encoded
 as MLSPlaintext objects in cases where it is necessary for the
 Delivery Service to examine such messages.
 
-~~~
+~~~ tls
 enum {
     reserved(0),
     mls10(1),
@@ -1446,7 +1436,7 @@ for their use.
 The following structure is used to fully describe the data transmitted in
 plaintexts or ciphertexts.
 
-~~~
+~~~ tls
 struct {
     WireFormat wire_format;
     MLSMessageContent content;
@@ -1458,7 +1448,7 @@ struct {
 
 MLSMessageContent is authenticated using the MLSMessageAuth structure.
 
-~~~
+~~~ tls
 struct {
     opaque mac_value<V>;
 } MAC;
@@ -1486,7 +1476,7 @@ If the sender is a member of the group, the content also covers the
 GroupContext for the current epoch, so that signatures are specific to a given
 group and epoch.
 
-~~~
+~~~ tls
 struct {
     ProtocolVersion version = mls10;
     WireFormat wire_format;
@@ -1512,7 +1502,7 @@ A MLSMessageAuth is said to be valid when both the `signature` and
 
 Plaintexts are encoded using the MLSPlaintext structure.
 
-~~~
+~~~ tls
 struct {
     MLSMessageContent content;
     MLSMessageAuth auth;
@@ -1530,13 +1520,15 @@ The `membership_tag` field in the MLSPlaintext object authenticates the sender's
 membership in the group. For messages sent by members, it MUST be set to the
 following value:
 
-~~~
+~~~ tls
 struct {
   MLSMessageContentTBS content_tbs;
   MLSMessageAuth auth;
 } MLSMessageContentTBM;
+~~~
 
-membership_tag = MAC(membership_key, MLSMessageContentTBM);
+~~~ pseudocode
+membership_tag = MAC(membership_key, MLSMessageContentTBM)
 ~~~
 
 
@@ -1548,7 +1540,7 @@ MLSMessageAuth is valid.
 
 Ciphertexts are encoded using the MLSCiphertext structure.
 
-~~~
+~~~ tls
 struct {
     opaque group_id<V>;
     uint64 epoch;
@@ -1567,7 +1559,7 @@ and MLSCiphertextContent.
 
 The ciphertext content is encoded using the MLSCiphertextContent structure.
 
-~~~
+~~~ tls
 struct {
     select (MLSCiphertext.content_type) {
         case application:
@@ -1605,7 +1597,7 @@ include the reuse guard in the `reuse_guard` field of the sender data object, so
 that the recipient of the message can use it to compute the nonce to be used for
 decryption.
 
-~~~
+~~~ ascii-art
 +-+-+-+-+---------...---+
 |   Key Schedule Nonce  |
 +-+-+-+-+---------...---+
@@ -1623,7 +1615,7 @@ The Additional Authenticated Data (AAD) input to the encryption
 contains an object of the following form, with the values used to
 identify the key and nonce:
 
-~~~
+~~~ tls
 struct {
     opaque group_id<V>;
     uint64 epoch;
@@ -1642,7 +1634,7 @@ encrypted with the ciphersuite's AEAD with a key and nonce derived from both the
 `sender_data_secret` and a sample of the encrypted content. Before being
 encrypted, the sender data is encoded as an object of the following form:
 
-~~~
+~~~ tls
 struct {
     LeafNodeRef sender;
     uint32 generation;
@@ -1662,7 +1654,7 @@ The key and nonce provided to the AEAD are computed as the KDF of the first
 length of the ciphertext is less than `KDF.Nh`, the whole ciphertext is used
 without padding. In pseudocode, the key and nonce are derived as:
 
-~~~
+~~~ pseudocode
 ciphertext_sample = ciphertext[0..KDF.Nh-1]
 
 sender_data_key = ExpandWithLabel(sender_data_secret, "key",
@@ -1674,7 +1666,7 @@ sender_data_nonce = ExpandWithLabel(sender_data_secret, "nonce",
 The Additional Authenticated Data (AAD) for the SenderData ciphertext is the
 first three fields of MLSCiphertext:
 
-~~~
+~~~ tls
 struct {
     opaque group_id<V>;
     uint64 epoch;
@@ -1701,7 +1693,7 @@ As discussed in {{ratchet-tree-nodes}}, the nodes of a ratchet tree contain
 several types of data describing individual members (for leaf nodes) or
 subgroups of the group (for parent nodes).  Parent nodes are simpler:
 
-~~~
+~~~ tls
 struct {
     HPKEPublicKey public_key;
     opaque parent_hash<V>;
@@ -1722,7 +1714,7 @@ appearance in the group, signed by that client. It is also used in client
 KeyPackage objects to store the information that will be needed to add a
 client to a group.
 
-~~~
+~~~ tls
 enum {
     reserved(0),
     key_package(1),
@@ -1949,7 +1941,7 @@ DeriveSecret and the node secret is used as an input to DeriveKeyPair.
 For example, suppose there is a group with four members, with C an unmerged leaf
 at Z:
 
-~~~
+~~~ ascii-art
       Y
     __|__
    /     \
@@ -1965,7 +1957,7 @@ If member B subsequently generates an UpdatePath based on a secret
 "leaf_secret", then it would generate the following sequence
 of path secrets:
 
-~~~
+~~~ ascii-art
 path_secret[1] --> node_secret[1] --> node_priv[1], node_pub[1]
      ^
      |
@@ -1980,7 +1972,7 @@ After applying the UpdatePath, the tree will have the following structure, where
 `lp` and `np[i]` represent the leaf_priv and node_priv values generated as
 described above:
 
-~~~
+~~~ ascii-art
     np[1] -> Y'
            __|__
           /     \
@@ -2011,7 +2003,7 @@ left-balanced (or set it as a new root).  The former right child of P's
 parent becomes P's left child (or the old root becomes P's left child if
 P is the new root).
 
-~~~
+~~~ ascii-art
                    _ <-- new parent              _
                  __|_                          __|__
                 /    \                        /     \
@@ -2025,7 +2017,7 @@ node P.  If P was the root of the tree, P's left child
 is now the root of the tree.  Otherwise, set the right child of P's parent
 to be P's left child.
 
-~~~
+~~~ ascii-art
       Y                                    Y
     __|__                                __|_
    /     \                              /    \
@@ -2135,7 +2127,7 @@ which we define recursively, starting with the leaves.
 The tree hash of a leaf node is the hash of leaf's `LeafNodeHashInput` object which
 might include a `LeafNode` object depending on whether or not it is blank.
 
-~~~
+~~~ tls
 struct {
     uint32 leaf_index;
     optional<LeafNode> leaf_node;
@@ -2146,7 +2138,7 @@ Now the tree hash of any non-leaf node is recursively defined to be the hash of
 its `ParentNodeHashInput`. This includes an optional `ParentNode`
 object depending on whether the node is blank or not.
 
-~~~
+~~~ tls
 struct {
     optional<ParentNode> parent_node;
     opaque left_hash<V>;
@@ -2167,7 +2159,7 @@ leaf node was last updated.
 
 Consider a ratchet tree with a non-blank parent node P and children V and S.
 
-~~~
+~~~ ascii-art
         ...
         /
        P
@@ -2184,7 +2176,7 @@ the ratchet tree along a path from a leaf U traversing node V (and hence also
 P). The new "Parent hash of P (with copath child S)" is obtained by hashing P's
 `ParentHashInput` struct.
 
-~~~
+~~~ tls
 struct {
     HPKEPublicKey public_key;
     opaque parent_hash<V>;
@@ -2212,7 +2204,7 @@ the following way:
 
 For example, in the following tree:
 
-~~~
+~~~ ascii-art
               W [D, H]
         ______|_____
        /             \
@@ -2229,7 +2221,7 @@ hash computations" }
 With P = W and S = Y, `original_sibling_tree_hash` is the tree hash of the
 following tree:
 
-~~~
+~~~ ascii-art
       Y [F]
     __|__
    /     \
@@ -2245,7 +2237,7 @@ last two nodes.
 With P = W and S = U, `original_sibling_tree_hash` is the tree hash of the
 following tree:
 
-~~~
+~~~ ascii-art
       U
     __|__
    /     \
@@ -2341,7 +2333,7 @@ root. The path is ordered
 from the closest node to the leaf to the root; each node MUST be the
 parent of its predecessor.
 
-~~~
+~~~ tls
 struct {
     opaque kem_output<V>;
     opaque ciphertext<V>;
@@ -2366,7 +2358,7 @@ encryption to the respective resolution node.
 
 The HPKECiphertext values are computed as
 
-~~~
+~~~ pseudocode
 kem_output, context = SetupBaseS(node_public_key, group_context)
 ciphertext = context.Seal("", path_secret)
 ~~~
@@ -2384,20 +2376,22 @@ key of the resolution node.
 Group keys are derived using the `Extract` and `Expand` functions from the KDF
 for the group's ciphersuite, as well as the functions defined below:
 
-~~~
+~~~ pseudocode
 ExpandWithLabel(Secret, Label, Context, Length) =
     KDF.Expand(Secret, KDFLabel, Length)
 
+DeriveSecret(Secret, Label) =
+    ExpandWithLabel(Secret, Label, "", KDF.Nh)
+~~~
+
 Where KDFLabel is specified as:
 
+~~~ tls
 struct {
     uint16 length = Length;
     opaque label<V> = "MLS 1.0 " + Label;
     opaque context<V> = Context;
 } KDFLabel;
-
-DeriveSecret(Secret, Label) =
-    ExpandWithLabel(Secret, Label, "", KDF.Nh)
 ~~~
 
 The value `KDF.Nh` is the size of an output from `KDF.Extract`, in bytes.  In
@@ -2418,7 +2412,7 @@ following information to derive new epoch secrets:
 Given these inputs, the derivation of secrets for an epoch
 proceeds as shown in the following diagram:
 
-~~~
+~~~ ascii-art
                    init_secret_[n-1]
                          |
                          V
@@ -2469,7 +2463,7 @@ A number of secrets are derived from the epoch secret for different purposes:
 The "external secret" is used to derive an HPKE key pair whose private key is
 held by the entire group:
 
-~~~
+~~~ pseudocode
 external_priv, external_pub = KEM.DeriveKeyPair(external_secret)
 ~~~
 
@@ -2481,7 +2475,7 @@ in order to allow non-members to join the group using an external commit.
 Each member of the group maintains a GroupContext object that
 summarizes the state of the group:
 
-~~~
+~~~ tls
 struct {
     opaque group_id<V>;
     uint64 epoch;
@@ -2534,7 +2528,7 @@ in which they were sent.
 The `confirmed_transcript_hash` is updated with an MLSMessageContent and
 MLSMessageAuth containing a Commit in two steps:
 
-~~~
+~~~ tls
 struct {
     WireFormat wire_format;
     MLSMessageContent content; //with content.content_type == commit
@@ -2544,7 +2538,9 @@ struct {
 struct {
     MAC confirmation_tag;
 } MLSMessageCommitAuthData;
+~~~
 
+~~~ pseudocode
 interim_transcript_hash_[0] = ""; // zero-length octet string
 
 confirmed_transcript_hash_[n] =
@@ -2578,7 +2574,7 @@ the HPKE export method.  The joiner then uses that `init_secret` with
 information provided in the GroupInfo and an external Commit to initialize
 their copy of the key schedule for the new epoch.
 
-~~~
+~~~ pseudocode
 kem_output, context = SetupBaseS(external_pub, "")
 init_secret = context.export("MLS 1.0 external init secret", KDF.Nh)
 ~~~
@@ -2586,7 +2582,7 @@ init_secret = context.export("MLS 1.0 external init secret", KDF.Nh)
 Members of the group receive the `kem_output` in an ExternalInit proposal and
 preform the corresponding calculation to retrieve the `init_secret` value.
 
-~~~
+~~~ pseudocode
 context = SetupBaseR(kem_output, external_priv, "")
 init_secret = context.export("MLS 1.0 external init secret", KDF.Nh)
 ~~~
@@ -2627,7 +2623,7 @@ Welcome message corresponding to the Commit.  To ensure that existing and new
 members compute the same PSK input to the key schedule, the Commit and
 GroupSecrets objects MUST indicate the same set of PSKs, in the same order.
 
-~~~
+~~~ tls
 enum {
   reserved(0),
   external(1),
@@ -2668,13 +2664,15 @@ For resumption PSKs, the PSK is defined as the `resumption_secret` of the group 
 epoch specified in the `PreSharedKeyID` object. Specifically, `psk_secret` is
 computed as follows:
 
-~~~
+~~~ tls
 struct {
     PreSharedKeyID id;
     uint16 index;
     uint16 count;
 } PSKLabel;
+~~~
 
+~~~ pseudocode
 psk_extracted_[i] = KDF.Extract(0, psk_[i])
 psk_input_[i] = ExpandWithLabel(psk_extracted_[i], "derived psk",
                   PSKLabel, KDF.Nh)
@@ -2690,7 +2688,7 @@ Here `0` represents the all-zero vector of length `KDF.Nh`. The `index` field in
 chained together with KDF.Extract invocations (labelled "Extract" for brevity
 in the diagram), as follows:
 
-~~~
+~~~ ascii-art
                  0                               0    = psk_secret_[0]
                  |                               |
                  V                               V
@@ -2716,7 +2714,7 @@ The main MLS key schedule provides an `exporter_secret` which can
 be used by an application as the basis to derive new secrets called
 `exported_value` outside the MLS layer.
 
-~~~
+~~~ pseudocode
 MLS-Exporter(Label, Context, key_length) =
        ExpandWithLabel(DeriveSecret(exporter_secret, Label),
                          "exporter", Hash(Context), key_length)
@@ -2765,7 +2763,7 @@ tree.
 If N is a parent node in the Secret Tree then the secrets of the children of N
 are defined as follows (where left(N) and right(N) denote the children of N):
 
-~~~
+~~~ ascii-art
 tree_node_[N]_secret
         |
         |
@@ -2780,7 +2778,7 @@ The secret in the leaf of the Secret Tree is used to initiate two symmetric hash
 ratchets, from which a sequence of single-use keys and nonces are derived, as
 described in {{encryption-keys}}. The root of each ratchet is computed as:
 
-~~~
+~~~ ascii-art
 tree_node_[N]_secret
         |
         |
@@ -2819,14 +2817,14 @@ Keys, nonces, and the secrets in ratchets are derived using
 DeriveTreeSecret. The context in a given call consists of the current position
 in the ratchet.
 
-~~~
+~~~ pseudocode
 DeriveTreeSecret(Secret, Label, Generation, Length) =
     ExpandWithLabel(Secret, Label, Generation, Length)
 
 Where Generation is encoded as a uint32.
 ~~~
 
-~~~
+~~~ ascii-art
 ratchet_secret_[N]_[j]
       |
       +--> DeriveTreeSecret(., "nonce", j, AEAD.Nn)
@@ -2877,7 +2875,7 @@ values have been consumed and MUST be deleted:
 Concretely, suppose we have the following Secret Tree and ratchet for
 participant D:
 
-~~~
+~~~ ascii-art
        G
      /   \
     /     \
@@ -2931,7 +2929,7 @@ The signature is computed by the function `SignWithLabel` with a label
 `KeyPackage` and a content comprising of all of the fields except for the
 signature field.
 
-~~~
+~~~ tls
 struct {
     ProtocolVersion version;
     CipherSuite cipher_suite;
@@ -2996,7 +2994,7 @@ Within MLS, a KeyPackage is identified by its hash (see, e.g.,
 {{joining-via-welcome-message}}).  The `external_key_id` extension allows
 applications to add an explicit, application-defined identifier to a KeyPackage.
 
-~~~
+~~~ tls
 opaque external_key_id<V>;
 ~~~
 
@@ -3058,7 +3056,7 @@ group.  At a minimum, all members of the group need to support the ciphersuite
 and protocol version in use.  Additional requirements can be imposed by
 including a `required_capabilities` extension in the GroupContext.
 
-~~~
+~~~ tls
 struct {
     ExtensionType extension_types<V>;
     ProposalType proposal_types<V>;
@@ -3155,7 +3153,7 @@ a state transition occurs, the epoch number is incremented by one.
 Proposals are included in an MLSMessageContent by way of a Proposal structure
 that indicates their type:
 
-~~~
+~~~ tls
 // See IANA registry for registered values
 uint16 ProposalType;
 
@@ -3185,7 +3183,7 @@ An Add proposal requests that a client with a specified KeyPackage be added
 to the group.  The proposer of the Add MUST verify the validity of the
 KeyPackage, as specified in {{keypackage-validation}}.
 
-~~~
+~~~ tls
 struct {
     KeyPackage key_package;
 } Add;
@@ -3217,7 +3215,7 @@ An Update proposal is a similar mechanism to Add with the distinction
 that it replaces the sender's LeafNode in the tree instead of adding a new leaf
 to the tree.
 
-~~~
+~~~ tls
 struct {
     LeafNode leaf_node;
 } Update;
@@ -3240,7 +3238,7 @@ A member of the group applies an Update message by taking the following steps:
 A Remove proposal requests that the member with LeafNodeRef `removed` be removed
 from the group.
 
-~~~
+~~~ tls
 struct {
     LeafNodeRef removed;
 } Remove;
@@ -3265,7 +3263,7 @@ A member of the group applies a Remove message by taking the following steps:
 A PreSharedKey proposal can be used to request that a pre-shared key be
 injected into the key schedule in the process of advancing the epoch.
 
-~~~
+~~~ tls
 struct {
     PreSharedKeyID psk;
 } PreSharedKey;
@@ -3284,7 +3282,7 @@ parameters, for example, to increase the version number or to change the
 ciphersuite. The reinitialization is done by creating a completely new group
 and shutting down the old one.
 
-~~~
+~~~ tls
 struct {
     opaque group_id<V>;
     ProtocolVersion version;
@@ -3308,7 +3306,7 @@ in the ReInit proposal MUST be no less than the version for the current group.
 An ExternalInit proposal is used by new members that want to join a group by
 using an external commit. This proposal can only be used in that context.
 
-~~~
+~~~ tls
 struct {
   opaque kem_output<V>;
 } ExternalInit;
@@ -3325,7 +3323,7 @@ Though this information implies no change to the group, it is structured as a
 Proposal message so that it is included in the group's transcript by being
 included in Commit messages.
 
-~~~
+~~~ tls
 struct {
     LeafNodeRef sender;
     uint32 first_generation;
@@ -3445,7 +3443,7 @@ for previously sent proposals from anyone (including the committer) can be sent
 by reference.  Proposals sent by reference are specified by including the hash of
 the MLSPlaintext in which the proposal was sent (see {{hash-based-identifiers}}).
 
-~~~
+~~~ tls
 enum {
   reserved(0),
   proposal(1)
@@ -3535,7 +3533,7 @@ appearance of the updated member.
 In pseudocode, the logic for validating the `path` field of a Commit is as
 follows:
 
-~~~
+~~~ pseudocode
 pathRequiredTypes = [
     update,
     remove,
@@ -3768,7 +3766,7 @@ New members can join the group in two ways. Either by being added by a group
 member, or by adding themselves through an external Commit. In both cases, the
 new members need information to bootstrap their local group state.
 
-~~~
+~~~ tls
 struct {
     CipherSuite cipher_suite;
     opaque group_id<V>;
@@ -3789,7 +3787,7 @@ credential in the leaf node of the member with LeafNodeRef `signer`. The
 signature covers the following structure, comprising all the fields in the
 GroupInfo above `signature`:
 
-~~~
+~~~ tls
 struct {
     CipherSuite cipher_suite;
     opaque group_id<V>;
@@ -3828,7 +3826,7 @@ following information for the group's current epoch:
 In other words, to join a group via an External Commit, a new member needs a
 GroupInfo with an `ExternalPub` extension present in the `other_extensions`.
 
-~~~
+~~~ tls
 struct {
     HPKEPublicKey external_pub;
 } ExternalPub;
@@ -3914,7 +3912,7 @@ If the sender of the Welcome message wants the receiving member to include a PSK
 in the derivation of the `epoch_secret`, they can populate the `psks` field
 indicating which PSK to use.
 
-~~~
+~~~ tls
 struct {
   opaque path_secret<V>;
 } PathSecret;
@@ -3961,7 +3959,7 @@ On receiving a Welcome message, a client processes it using the following steps:
   the `welcome_key` and `welcome_nonce`. Use the key and nonce to decrypt the
   `encrypted_group_info` field.
 
-~~~
+~~~ pseudocode
 welcome_nonce = KDF.Expand(welcome_secret, "nonce", AEAD.Nn)
 welcome_key = KDF.Expand(welcome_secret, "key", AEAD.Nk)
 ~~~
@@ -4038,7 +4036,7 @@ In cases where the application does not wish to provide such an external source,
 the whole public state of the ratchet tree can be provided in an extension of
 type `ratchet_tree`, containing a `ratchet_tree` object of the following form:
 
-~~~
+~~~ tls
 enum {
     reserved(0),
     leaf(1),
@@ -4069,7 +4067,7 @@ that 2^k is smaller than the length of the array. Intermediate parent nodes can
 be identified by performing the same calculation to the subarrays to the left
 and right of the root, following something like the following algorithm:
 
-~~~
+~~~ python
 # Assuming a class Node that has left and right members
 def subtree_root(nodes):
     # If there is only one node in the array return it
@@ -4099,7 +4097,7 @@ The example tree in {{ratchet-tree-terminology}} would be represented as an
 array of nodes in the following form, where R represents the "subtree root" for
 a given subarray of the node array:
 
-~~~
+~~~ ascii-art
               X
         ______|______
        /             \
@@ -4535,13 +4533,13 @@ cryptographic algorithms that should be used.
 
 Ciphersuite names follow the naming convention:
 
-~~~
+~~~ tls
 CipherSuite MLS_LVL_KEM_AEAD_HASH_SIG = VALUE;
 ~~~
 
 Where VALUE is represented as a sixteen-bit integer:
 
-~~~
+~~~ tls
 uint16 CipherSuite;
 ~~~
 
@@ -4770,7 +4768,7 @@ MLS DE, that MLS DE SHOULD defer to the judgment of the other MLS DEs.
 This document registers the "message/mls" MIME media type in order to allow other
 protocols (ex: HTTP {{!RFC7540}}) to convey MLS messages.
 
-~~~
+~~~ ascii-art
   Media type name: message
   Media subtype name: mls
   Required parameters: none
@@ -4893,7 +4891,7 @@ even-numbered nodes, with the n-th leaf at 2\*n.  Intermediate nodes
 are held in odd-numbered nodes.  For example, tree with 11 leaves has
 the following structure:
 
-~~~
+~~~ ascii-art
                                                    X
                            X
                X                       X                       X
@@ -4908,7 +4906,7 @@ manipulating indices, rather than having to maintain complicated structures in
 memory. The basic rule is that the high-order bits of parent and child nodes
 indices have the following relation (where `x` is an arbitrary bit string):
 
-~~~
+~~~ pseudocode
 parent=01x => left=00x, right=10x
 ~~~
 
@@ -4922,7 +4920,7 @@ nodes at the right edge of the tree are quite simple:
 The following python code demonstrates the tree computations necessary to use an
 array-based tree for MLS.
 
-~~~
+~~~ python
 # The exponent of the largest power of 2 less than x. Equivalent to:
 #   int(math.floor(math.log(x, 2)))
 def log2(x):
@@ -5072,7 +5070,7 @@ or truncated when memebers are removed.
 The following code snippet shows how these algorithms could be implemented in
 Python.
 
-~~~
+~~~ python
 class Node:
     def __init__(self, value, parent=None, left=None, right=None):
         self.value = value    # Value of the node

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -476,7 +476,7 @@ An optional value is encoded with a presence-signaling octet, followed by the
 value itself if present.  When decoding, a presence octet with a value other
 than 0 or 1 MUST be rejected as malformed.
 
-~~~~~
+~~~
 struct {
     uint8 present;
     select (present) {
@@ -484,7 +484,7 @@ struct {
         case 1: T value;
     }
 } optional<T>;
-~~~~~
+~~~
 
 ### Variable-size Vector Headers
 
@@ -499,12 +499,12 @@ a variable-length integer encoding based on the one in Section 16 of
 encoding.) Instead of presenting min and max values, the vector description
 simply includes a `V`. For example:
 
-~~~~~
+~~~
 struct {
     uint32 fixed<0..255>;
     opaque variable<V>;
 } StructWithVectors;
-~~~~~
+~~~
 
 Such a vector can represent values with length from 0 bytes to 2^30 bytes.
 The variable-length integer encoding reserves the two most significant bits
@@ -534,7 +534,7 @@ decodes to 37.
 The following figure adapts the pseudocode provided in {{RFC9000}} to add a
 check for minimum-length encoding:
 
-~~~~~
+~~~
 ReadVarint(data):
   // The length of variable-length integers is encoded in the
   // first two bits of the first byte.
@@ -552,7 +552,7 @@ ReadVarint(data):
   // Check that the encoder used the minimum bits required
   if length > 1 && v < (1 << (length - 1)):
     raise an exception
-~~~~~
+~~~
 
 The use of variable-size integers for vector lengths allows vectors to grow
 very large, up to 2^30 bytes.  Implementations should take care not to allow
@@ -625,7 +625,7 @@ both Proposal/Commit messages as well as any application data.
 
 The cryptographic state at the core of MLS is divided into three areas of responsibility:
 
-~~~~~
+~~~
                            epoch_secret
                          _      |      _
 |\ Ratchet              /      ...      \                    Secret /|
@@ -639,7 +639,7 @@ The cryptographic state at the core of MLS is divided into three areas of respon
 |/                      \_      |      _/                           \|
                                 V
                            epoch_secret
-~~~~~
+~~~
 {: title="Overview of MLS group evolution"}
 
 * A _ratchet tree_ that represents the membership of the group, providing group
@@ -707,7 +707,7 @@ MLSPlaintext or MLSCiphertext objects.
 Before the initialization of a group, clients publish KeyPackages to a directory
 provided by the Service Provider.
 
-~~~~~
+~~~
                                                                Group
 A                B                C            Directory       Channel
 |                |                |                |              |
@@ -720,7 +720,7 @@ A                B                C            Directory       Channel
 |                |                | KeyPackageC    |              |
 |                |                |--------------->|              |
 |                |                |                |              |
-~~~~~
+~~~
 {: title="Clients A, B, and C publish KeyPackages to the directory"}
 
 When a client A wants to establish a group with B and C, it first initializes a
@@ -735,7 +735,7 @@ Upon receiving the Welcome message, the new member will be able to read and send
 new messages to the group. However, messages sent before they were added to the
 group will not be accessible.
 
-~~~~~
+~~~
                                                                Group
 A              B              C          Directory            Channel
 |              |              |              |                   |
@@ -766,7 +766,7 @@ A              B              C          Directory            Channel
 |<---------------------------------------------------------------|
 |              |<------------------------------------------------|
 |              |              |              |                   |
-~~~~~
+~~~
 {: title="Client A creates a group with clients B and C"}
 
 Subsequent additions of group members proceed in the same way.  Any
@@ -787,7 +787,7 @@ is active, and members that don't update should eventually be removed from the
 group. It's left to the application to determine an appropriate amount of time
 between Updates.
 
-~~~~~
+~~~
                                                           Group
 A              B     ...      Z          Directory        Channel
 |              |              |              |              |
@@ -802,7 +802,7 @@ A              B     ...      Z          Directory        Channel
 |              |<-------------------------------------------|
 |              |              |<----------------------------|
 |              |              |              |              |
-~~~~~
+~~~
 {: title="Client B proposes to update its key, and client A commits the
 proposal.  As a result, the keys for both B and A updated, so the group has
 post-compromise security with respect to both of them."}
@@ -817,7 +817,7 @@ is actually allowed to evict other members; groups can
 enforce access control policies on top of these
 basic mechanism.
 
-~~~~~
+~~~
                                                           Group
 A              B     ...      Z          Directory       Channel
 |              |              |              |              |
@@ -830,7 +830,7 @@ A              B     ...      Z          Directory       Channel
 |<----------------------------------------------------------|
 |              |              |<----------------------------|
 |              |              |              |              |
-~~~~~
+~~~
 {: title="Client Z removes client B from the group"}
 
 ## Relationships Between Epochs
@@ -849,7 +849,7 @@ different parameters. Branching starts a new group with a subset of the original
 group's participants (with no effect on the original group).  In both cases,
 the new group is linked to the old group via a resumption PSK.
 
-~~~~~
+~~~
 epoch_A_[n-1]
      |
      |
@@ -863,11 +863,11 @@ epoch_A_[n]           epoch_B_[0]
                            |
                            V
                       epoch_B_[1]
-~~~~~
+~~~
 {: title="Reinitializing a group" }
 
 
-~~~~~
+~~~
 epoch_A_[n-1]
      |
      |
@@ -881,7 +881,7 @@ epoch_A_[n]           epoch_B_[0]
      |                     |
      V                     V
 epoch_A_[n+1]         epoch_B_[1]
-~~~~~
+~~~
 {: title="Branching a group" }
 
 Applications may also choose to use resumption PSKs to link epochs in other
@@ -890,7 +890,7 @@ from epoch `n` is injected into epoch `n+k`.  This demonstrates that the members
 of the group at epoch `n+k` were also members at epoch `n`, irrespective of any
 changes to these members' keys due to Updates or Commits.
 
-~~~~~
+~~~
 epoch_A_[n-1]
      |
      |
@@ -914,7 +914,7 @@ epoch_A_[n+k-1]           .
      |
      V
 epoch_A_[n+k]
-~~~~~
+~~~
 {: title="Reinjecting entropy from an earlier epoch" }
 
 # Ratchet Tree Concepts
@@ -980,7 +980,7 @@ For example, in the below tree:
 * The direct path of C is (W, V, X)
 * The copath of C is (D, U, Z)
 
-~~~~~
+~~~
               X = root
         ______|______
        /             \
@@ -992,7 +992,7 @@ For example, in the below tree:
 A   B   C   D   E   F   G
 
 0   1   2   3   4   5   6
-~~~~~
+~~~
 {: #full-tree title="A complete tree with seven members" }
 
 A tree with `n` leaves has `2*n - 1` nodes.  For example, the above tree has 7
@@ -1053,7 +1053,7 @@ private keys of the tree held by each participant would be as follows, where `_`
 represents a blank node, `?` represents an unknown private key, and `pk(X)`
 represents the public key corresponding to the private key `X`:
 
-~~~~~
+~~~
          Public Tree
 ============================
             pk(ABCD)
@@ -1070,7 +1070,7 @@ pk(A)   pk(B)   pk(C)   pk(D)
   AB      _         AB      _         ?       _         ?       _
  / \     / \       / \     / \       / \     / \       / \     / \
 A   ?   ?   ?     ?   B   ?   ?     ?   ?   C   ?     ?   ?   ?   D
-~~~~~
+~~~
 
 Note how the tree invariant applies: Each member knows only their own leaf, and
 the private key AB is known only to A and B.
@@ -1111,7 +1111,7 @@ For example, consider the following subtree, where the `_` character
 represents a blank node and unmerged leaves are indicated in square
 brackets:
 
-~~~~~
+~~~
        ...
        /
       _
@@ -1122,7 +1122,7 @@ brackets:
 A   _   C   D
 
 0   1   2   3
-~~~~~
+~~~
 {: #resolution-tree title="A tree with blanks and unmerged leaves" }
 
 In this tree, we can see all of the above rules in play:
@@ -1162,9 +1162,9 @@ are opaque values in a format defined by the underlying
 protocol (see the Cryptographic Dependencies section of the HPKE specification for more
 information).
 
-~~~~~
+~~~
 opaque HPKEPublicKey<V>;
-~~~~~
+~~~
 
 The signature algorithm specified in the ciphersuite is the mandatory algorithm
 to be used for signatures in MLSMessageAuth and the tree signatures.  It MUST be
@@ -1175,7 +1175,7 @@ members).
 To disambiguate different signatures used in MLS, each signed value is prefixed
 by a label as shown below:
 
-~~~~~
+~~~
 SignWithLabel(SignatureKey, Label, Content) =
     Signature.Sign(SignatureKey, SignContent)
 
@@ -1188,7 +1188,7 @@ struct {
     opaque label<V> = "MLS 1.0 " + Label;
     opaque content<V> = Content;
 } SignContent;
-~~~~~
+~~~
 
 Here, the functions `Signature.Sign` and `Signature.Verify` are defined
 by the signature algorithm.
@@ -1201,7 +1201,7 @@ Some MLS messages refer to other MLS objects by hash.  For example, Welcome
 messages refer to KeyPackages for the members being welcomed, and Commits refer
 to Proposals they cover.  These identifiers are computed as follows:
 
-~~~~~
+~~~
 opaque HashReference[16];
 
 MakeKeyPackageRef(value) = KDF.expand(
@@ -1216,7 +1216,7 @@ MakeProposalRef(value) = KDF.expand(
 HashReference KeyPackageRef;
 HashReference LeafNodeRef;
 HashReference ProposalRef;
-~~~~~
+~~~
 
 For a KeyPackageRef, the `value` input is the encoded KeyPackage, and the
 ciphersuite specified in the KeyPackage determines the KDF used.  For a
@@ -1254,7 +1254,7 @@ to verify the identity / signing key binding.
 Additionally, Credentials SHOULD specify the signature scheme corresponding to
 each contained public key.
 
-~~~~~
+~~~
 // See RFC 8446 and the IANA TLS SignatureScheme registry
 uint16 SignatureScheme;
 
@@ -1281,7 +1281,7 @@ struct {
             Certificate chain<V>;
     };
 } Credential;
-~~~~~
+~~~
 
 A BasicCredential is a raw, unauthenticated assertion of an identity/key
 binding. The format of the key in the `public_key` field is defined by the
@@ -1360,7 +1360,7 @@ handshake messages, but MAY transmit handshake messages encoded
 as MLSPlaintext objects in cases where it is necessary for the
 Delivery Service to examine such messages.
 
-~~~~~
+~~~
 enum {
     reserved(0),
     mls10(1),
@@ -1438,7 +1438,7 @@ struct {
             KeyPackage key_package;
     }
 } MLSMessage;
-~~~~~
+~~~
 
 External sender types are sent as MLSPlaintext, see {{external-proposals}}
 for their use.
@@ -1446,19 +1446,19 @@ for their use.
 The following structure is used to fully describe the data transmitted in
 plaintexts or ciphertexts.
 
-~~~~~
+~~~
 struct {
     WireFormat wire_format;
     MLSMessageContent content;
     MLSMessageAuth auth;
 } MLSMessageContentAuth;
-~~~~~
+~~~
 
 ## Content Authentication
 
 MLSMessageContent is authenticated using the MLSMessageAuth structure.
 
-~~~~~
+~~~
 struct {
     opaque mac_value<V>;
 } MAC;
@@ -1475,7 +1475,7 @@ struct {
             struct{};
     }
 } MLSMessageAuth;
-~~~~~
+~~~
 
 The `signature` field in an MLSMessageAuth object is computed using the signing
 private key corresponding to the public key, which was authenticated by the
@@ -1486,7 +1486,7 @@ If the sender is a member of the group, the content also covers the
 GroupContext for the current epoch, so that signatures are specific to a given
 group and epoch.
 
-~~~~~
+~~~
 struct {
     ProtocolVersion version = mls10;
     WireFormat wire_format;
@@ -1500,7 +1500,7 @@ struct {
             struct{};
     }
 } MLSMessageContentTBS;
-~~~~~
+~~~
 
 The confirmation tag value confirms that the members of the group have arrived
 at the same state of the group.
@@ -1512,7 +1512,7 @@ A MLSMessageAuth is said to be valid when both the `signature` and
 
 Plaintexts are encoded using the MLSPlaintext structure.
 
-~~~~~
+~~~
 struct {
     MLSMessageContent content;
     MLSMessageAuth auth;
@@ -1524,20 +1524,20 @@ struct {
             struct{};
     }
 } MLSPlaintext;
-~~~~~
+~~~
 
 The `membership_tag` field in the MLSPlaintext object authenticates the sender's
 membership in the group. For messages sent by members, it MUST be set to the
 following value:
 
-~~~~~
+~~~
 struct {
   MLSMessageContentTBS content_tbs;
   MLSMessageAuth auth;
 } MLSMessageContentTBM;
 
 membership_tag = MAC(membership_key, MLSMessageContentTBM);
-~~~~~
+~~~
 
 
 When decoding a MLSPlaintext into a MLSMessageContentAuth,
@@ -1548,7 +1548,7 @@ MLSMessageAuth is valid.
 
 Ciphertexts are encoded using the MLSCiphertext structure.
 
-~~~~~
+~~~
 struct {
     opaque group_id<V>;
     uint64 epoch;
@@ -1557,7 +1557,7 @@ struct {
     opaque encrypted_sender_data<V>;
     opaque ciphertext<V>;
 } MLSCiphertext;
-~~~~~
+~~~
 
 `encrypted_sender_data` and `ciphertext` are encrypted using the AEAD function
 specified by the ciphersuite in use, using as input the structures MLSSenderData
@@ -1567,7 +1567,7 @@ and MLSCiphertextContent.
 
 The ciphertext content is encoded using the MLSCiphertextContent structure.
 
-~~~~~
+~~~
 struct {
     select (MLSCiphertext.content_type) {
         case application:
@@ -1583,7 +1583,7 @@ struct {
     MLSMessageAuth auth;
     opaque padding<V>;
 } MLSCiphertextContent;
-~~~~~
+~~~
 
 In the MLS key schedule, the sender creates two distinct key ratchets for
 handshake and application messages for each member of the group. When encrypting
@@ -1605,7 +1605,7 @@ include the reuse guard in the `reuse_guard` field of the sender data object, so
 that the recipient of the message can use it to compute the nonce to be used for
 decryption.
 
-~~~~~
+~~~
 +-+-+-+-+---------...---+
 |   Key Schedule Nonce  |
 +-+-+-+-+---------...---+
@@ -1617,20 +1617,20 @@ decryption.
 +-+-+-+-+---------...---+
 | Encrypt/Decrypt Nonce |
 +-+-+-+-+---------...---+
-~~~~~
+~~~
 
 The Additional Authenticated Data (AAD) input to the encryption
 contains an object of the following form, with the values used to
 identify the key and nonce:
 
-~~~~~
+~~~
 struct {
     opaque group_id<V>;
     uint64 epoch;
     ContentType content_type;
     opaque authenticated_data<V>;
 } MLSCiphertextContentAAD;
-~~~~~
+~~~
 
 When decoding a MLSCiphertextContent, the application MUST check that the
 MLSMessageAuth is valid.
@@ -1642,13 +1642,13 @@ encrypted with the ciphersuite's AEAD with a key and nonce derived from both the
 `sender_data_secret` and a sample of the encrypted content. Before being
 encrypted, the sender data is encoded as an object of the following form:
 
-~~~~~
+~~~
 struct {
     LeafNodeRef sender;
     uint32 generation;
     opaque reuse_guard[4];
 } MLSSenderData;
-~~~~~
+~~~
 
 MLSSenderData.sender is assumed to be a `member` sender type.  When constructing
 an MLSSenderData from a Sender object, the sender MUST verify Sender.sender_type
@@ -1662,25 +1662,25 @@ The key and nonce provided to the AEAD are computed as the KDF of the first
 length of the ciphertext is less than `KDF.Nh`, the whole ciphertext is used
 without padding. In pseudocode, the key and nonce are derived as:
 
-~~~~~
+~~~
 ciphertext_sample = ciphertext[0..KDF.Nh-1]
 
 sender_data_key = ExpandWithLabel(sender_data_secret, "key",
                       ciphertext_sample, AEAD.Nk)
 sender_data_nonce = ExpandWithLabel(sender_data_secret, "nonce",
                       ciphertext_sample, AEAD.Nn)
-~~~~~
+~~~
 
 The Additional Authenticated Data (AAD) for the SenderData ciphertext is the
 first three fields of MLSCiphertext:
 
-~~~~~
+~~~
 struct {
     opaque group_id<V>;
     uint64 epoch;
     ContentType content_type;
 } MLSSenderDataAAD;
-~~~~~
+~~~
 
 When parsing a SenderData struct as part of message decryption, the recipient
 MUST verify that the LeafNodeRef indicated in the `sender` field identifies a
@@ -1701,13 +1701,13 @@ As discussed in {{ratchet-tree-nodes}}, the nodes of a ratchet tree contain
 several types of data describing individual members (for leaf nodes) or
 subgroups of the group (for parent nodes).  Parent nodes are simpler:
 
-~~~~~
+~~~
 struct {
     HPKEPublicKey public_key;
     opaque parent_hash<V>;
     uint32 unmerged_leaves<V>;
 } ParentNode;
-~~~~~
+~~~
 
 The `public_key` field contains an HPKE public key whose private key is held only
 by the members at the leaves among its descendants.  The `parent_hash` field
@@ -1722,7 +1722,7 @@ appearance in the group, signed by that client. It is also used in client
 KeyPackage objects to store the information that will be needed to add a
 client to a group.
 
-~~~~~
+~~~
 enum {
     reserved(0),
     key_package(1),
@@ -1803,7 +1803,7 @@ struct {
             opaque group_id<V>;
     }
 } LeafNodeTBS;
-~~~~~
+~~~
 
 The `public_key` field conains an HPKE public key whose private key is held only
 by the member occupying this leaf (or in the case of a LeafNode in a KeyPackage
@@ -1929,18 +1929,18 @@ equivalent to using the key pair of the removed node.
   path, as follows. In this setting, `path_secret[0]` refers to the first parent node
   in the filtered direct path, `path_secret[1]` to the second parent node, and so on.
 
-  ~~~~~
-  path_secret[0] is sampled at random
-  path_secret[n] = DeriveSecret(path_secret[n-1], "path")
-  ~~~~~
+~~~ pseudocode
+path_secret[0] is sampled at random
+path_secret[n] = DeriveSecret(path_secret[n-1], "path")
+~~~
 
 * Compute the sequence of HPKE key pairs `(node_priv,node_pub)`, one for each
   node on the leaf's direct path, as follows.
 
-  ~~~~~
-  node_secret[n] = DeriveSecret(path_secret[n], "node")
-  node_priv[n], node_pub[n] = KEM.DeriveKeyPair(node_secret[n])
-  ~~~~~
+~~~ pseudocode
+node_secret[n] = DeriveSecret(path_secret[n], "node")
+node_priv[n], node_pub[n] = KEM.DeriveKeyPair(node_secret[n])
+~~~
 
 The node secret is derived as a temporary intermediate secret so that each
 secret is only used with one algorithm: The path secret is used as an input to
@@ -1949,7 +1949,7 @@ DeriveSecret and the node secret is used as an input to DeriveKeyPair.
 For example, suppose there is a group with four members, with C an unmerged leaf
 at Z:
 
-~~~~~
+~~~
       Y
     __|__
    /     \
@@ -1958,14 +1958,14 @@ at Z:
 A   B   C   D
 
 0   1   2   3
-~~~~~
+~~~
 {: #evolution-tree title="A full tree with one unmerged leaf" }
 
 If member B subsequently generates an UpdatePath based on a secret
 "leaf_secret", then it would generate the following sequence
 of path secrets:
 
-~~~~~
+~~~
 path_secret[1] --> node_secret[1] --> node_priv[1], node_pub[1]
      ^
      |
@@ -1974,13 +1974,13 @@ path_secret[0] --> node_secret[0] --> node_priv[0], node_pub[0]
      |
 leaf_secret    --> leaf_node_secret --> leaf_priv, leaf_pub
                                      ~> leaf_node
-~~~~~
+~~~
 
 After applying the UpdatePath, the tree will have the following structure, where
 `lp` and `np[i]` represent the leaf_priv and node_priv values generated as
 described above:
 
-~~~~~
+~~~
     np[1] -> Y'
            __|__
           /     \
@@ -1992,7 +1992,7 @@ np[0] -> X'      Z[C]
            lp
 
        0   1   2   3
-~~~~~
+~~~
 
 ## Adding and Removing Leaves
 
@@ -2011,21 +2011,21 @@ left-balanced (or set it as a new root).  The former right child of P's
 parent becomes P's left child (or the old root becomes P's left child if
 P is the new root).
 
-~~~~~
+~~~
                    _ <-- new parent              _
                  __|_                          __|__
                 /    \                        /     \
   X    ===>    X     |               ===>    X       _ <-- new parent
  / \          / \    |                      / \     / \
 A   B        A   B   C <-- new leaf        A   B   C   D <-- new leaf
-~~~~~
+~~~
 
 To remove the rightmost leaf: Remove the rightmost leaf node L and its parent
 node P.  If P was the root of the tree, P's left child
 is now the root of the tree.  Otherwise, set the right child of P's parent
 to be P's left child.
 
-~~~~~
+~~~
       Y                                    Y
     __|__                                __|_
    /     \                              /    \
@@ -2040,7 +2040,7 @@ A   B   C   D <-- remove leaf        A   B   C
   X     |                  ===>    X <-- reassign root
  / \    |                         / \
 A   B   C <-- remove leaf        A   B
-~~~~~
+~~~
 
 Note that in the rest of the protocol, the rightmost leaf will only be removed when it is blank.
 
@@ -2135,24 +2135,24 @@ which we define recursively, starting with the leaves.
 The tree hash of a leaf node is the hash of leaf's `LeafNodeHashInput` object which
 might include a `LeafNode` object depending on whether or not it is blank.
 
-~~~~~
+~~~
 struct {
     uint32 leaf_index;
     optional<LeafNode> leaf_node;
 } LeafNodeHashInput;
-~~~~~
+~~~
 
 Now the tree hash of any non-leaf node is recursively defined to be the hash of
 its `ParentNodeHashInput`. This includes an optional `ParentNode`
 object depending on whether the node is blank or not.
 
-~~~~~
+~~~
 struct {
     optional<ParentNode> parent_node;
     opaque left_hash<V>;
     opaque right_hash<V>;
 } ParentNodeHashInput;
-~~~~~
+~~~
 
 The `left_hash` and `right_hash` fields hold the tree hashes of the node's
 left and right children, respectively.
@@ -2167,7 +2167,7 @@ leaf node was last updated.
 
 Consider a ratchet tree with a non-blank parent node P and children V and S.
 
-~~~~~
+~~~
         ...
         /
        P
@@ -2176,7 +2176,7 @@ Consider a ratchet tree with a non-blank parent node P and children V and S.
    V       S
   / \     / \
 ... ... ... ...
-~~~~~
+~~~
 
 
 The parent hash of P changes whenever an `UpdatePath` object is applied to
@@ -2184,13 +2184,13 @@ the ratchet tree along a path from a leaf U traversing node V (and hence also
 P). The new "Parent hash of P (with copath child S)" is obtained by hashing P's
 `ParentHashInput` struct.
 
-~~~~~
+~~~
 struct {
     HPKEPublicKey public_key;
     opaque parent_hash<V>;
     opaque original_sibling_tree_hash<V>;
 } ParentHashInput;
-~~~~~
+~~~
 
 The field `public_key` contains the HPKE public key of P. If P is the root,
 then the `parent_hash` field is set to a zero-length octet string. Otherwise,
@@ -2212,7 +2212,7 @@ the following way:
 
 For example, in the following tree:
 
-~~~~~
+~~~
               W [D, H]
         ______|_____
        /             \
@@ -2222,21 +2222,21 @@ For example, in the following tree:
   T       _       X [F]   _
  / \     / \     / \     / \
 A   B   C   D   E   F   G   H
-~~~~~
+~~~
 {: #parent-hash-tree title="A full tree unmerged leaves that illustrate parent
 hash computations" }
 
 With P = W and S = Y, `original_sibling_tree_hash` is the tree hash of the
 following tree:
 
-~~~~~
+~~~
       Y [F]
     __|__
    /     \
   X [F]  |
  / \     |
 E   F    G
-~~~~~
+~~~
 
 Because `W.unmerged_leaves = [H]`, H is removed from `Y.unmerged_leaves`,
 then H is replaced with a blank leaf, then the tree is truncated removing the
@@ -2245,14 +2245,14 @@ last two nodes.
 With P = W and S = U, `original_sibling_tree_hash` is the tree hash of the
 following tree:
 
-~~~~~
+~~~
       U
     __|__
    /     \
   T       _
  / \     / \
 A   B   C   _
-~~~~~
+~~~
 
 This time we have 4 leaf nodes because the truncation of the ratchet tree didn't
 remove the last leaf.
@@ -2341,7 +2341,7 @@ root. The path is ordered
 from the closest node to the leaf to the root; each node MUST be the
 parent of its predecessor.
 
-~~~~~
+~~~
 struct {
     opaque kem_output<V>;
     opaque ciphertext<V>;
@@ -2356,7 +2356,7 @@ struct {
     LeafNode leaf_node;
     UpdatePathNode nodes<V>;
 } UpdatePath;
-~~~~~
+~~~
 
 For each `UpdatePathNode`, the resolution of the corresponding copath node MUST
 be filtered by removing all new leaf nodes added as part of this MLS Commit
@@ -2366,10 +2366,10 @@ encryption to the respective resolution node.
 
 The HPKECiphertext values are computed as
 
-~~~~~
+~~~
 kem_output, context = SetupBaseS(node_public_key, group_context)
 ciphertext = context.Seal("", path_secret)
-~~~~~
+~~~
 
 where `node_public_key` is the public key of the node that the path
 secret is being encrypted for, group_context is the current GroupContext object
@@ -2384,7 +2384,7 @@ key of the resolution node.
 Group keys are derived using the `Extract` and `Expand` functions from the KDF
 for the group's ciphersuite, as well as the functions defined below:
 
-~~~~~
+~~~
 ExpandWithLabel(Secret, Label, Context, Length) =
     KDF.Expand(Secret, KDFLabel, Length)
 
@@ -2398,7 +2398,7 @@ struct {
 
 DeriveSecret(Secret, Label) =
     ExpandWithLabel(Secret, Label, "", KDF.Nh)
-~~~~~
+~~~
 
 The value `KDF.Nh` is the size of an output from `KDF.Extract`, in bytes.  In
 the below diagram:
@@ -2418,7 +2418,7 @@ following information to derive new epoch secrets:
 Given these inputs, the derivation of secrets for an epoch
 proceeds as shown in the following diagram:
 
-~~~~~
+~~~
                    init_secret_[n-1]
                          |
                          V
@@ -2450,7 +2450,7 @@ psk_secret (or 0) -> KDF.Extract
                          |
                          V
                    init_secret_[n]
-~~~~~
+~~~
 
 A number of secrets are derived from the epoch secret for different purposes:
 
@@ -2469,9 +2469,9 @@ A number of secrets are derived from the epoch secret for different purposes:
 The "external secret" is used to derive an HPKE key pair whose private key is
 held by the entire group:
 
-~~~~~
+~~~
 external_priv, external_pub = KEM.DeriveKeyPair(external_secret)
-~~~~~
+~~~
 
 The public key `external_pub` can be published as part of the GroupInfo struct
 in order to allow non-members to join the group using an external commit.
@@ -2481,7 +2481,7 @@ in order to allow non-members to join the group using an external commit.
 Each member of the group maintains a GroupContext object that
 summarizes the state of the group:
 
-~~~~~
+~~~
 struct {
     opaque group_id<V>;
     uint64 epoch;
@@ -2489,7 +2489,7 @@ struct {
     opaque confirmed_transcript_hash<V>;
     Extension extensions<V>;
 } GroupContext;
-~~~~~
+~~~
 
 The fields in this state have the following semantics:
 
@@ -2534,7 +2534,7 @@ in which they were sent.
 The `confirmed_transcript_hash` is updated with an MLSMessageContent and
 MLSMessageAuth containing a Commit in two steps:
 
-~~~~~
+~~~
 struct {
     WireFormat wire_format;
     MLSMessageContent content; //with content.content_type == commit
@@ -2554,7 +2554,7 @@ confirmed_transcript_hash_[n] =
 interim_transcript_hash_[n+1] =
     Hash(confirmed_transcript_hash_[n] ||
         MLSMessageCommitAuthData_[n]);
-~~~~~
+~~~
 
 Thus the `confirmed_transcript_hash` field in a GroupContext object represents a
 transcript over the whole history of MLSMessage Commit messages, up to the
@@ -2578,18 +2578,18 @@ the HPKE export method.  The joiner then uses that `init_secret` with
 information provided in the GroupInfo and an external Commit to initialize
 their copy of the key schedule for the new epoch.
 
-~~~~~
+~~~
 kem_output, context = SetupBaseS(external_pub, "")
 init_secret = context.export("MLS 1.0 external init secret", KDF.Nh)
-~~~~~
+~~~
 
 Members of the group receive the `kem_output` in an ExternalInit proposal and
 preform the corresponding calculation to retrieve the `init_secret` value.
 
-~~~~~
+~~~
 context = SetupBaseR(kem_output, external_priv, "")
 init_secret = context.export("MLS 1.0 external init secret", KDF.Nh)
-~~~~~
+~~~
 
 In both cases, the `info` input to HPKE is set to the GroupInfo for the
 previous epoch, encoded using the TLS serialization.
@@ -2627,7 +2627,7 @@ Welcome message corresponding to the Commit.  To ensure that existing and new
 members compute the same PSK input to the key schedule, the Commit and
 GroupSecrets objects MUST indicate the same set of PSKs, in the same order.
 
-~~~~~
+~~~
 enum {
   reserved(0),
   external(1),
@@ -2659,7 +2659,7 @@ struct {
 struct {
     PreSharedKeyID psks<V>;
 } PreSharedKeys;
-~~~~~
+~~~
 
 On receiving a Commit with a `PreSharedKey` proposal or a GroupSecrets object
 with the `psks` field set, the receiving Client includes them in the key
@@ -2668,7 +2668,7 @@ For resumption PSKs, the PSK is defined as the `resumption_secret` of the group 
 epoch specified in the `PreSharedKeyID` object. Specifically, `psk_secret` is
 computed as follows:
 
-~~~~~
+~~~
 struct {
     PreSharedKeyID id;
     uint16 index;
@@ -2682,7 +2682,7 @@ psk_input_[i] = ExpandWithLabel(psk_extracted_[i], "derived psk",
 psk_secret_[0] = 0
 psk_secret_[i] = KDF.Extract(psk_input_[i-1], psk_secret_[i-1])
 psk_secret     = psk_secret_[n]
-~~~~~
+~~~
 
 Here `0` represents the all-zero vector of length `KDF.Nh`. The `index` field in
 `PSKLabel` corresponds to the index of the PSK in the `psk` array, while the
@@ -2690,7 +2690,7 @@ Here `0` represents the all-zero vector of length `KDF.Nh`. The `index` field in
 chained together with KDF.Extract invocations (labelled "Extract" for brevity
 in the diagram), as follows:
 
-~~~~~
+~~~
                  0                               0    = psk_secret_[0]
                  |                               |
                  V                               V
@@ -2705,7 +2705,7 @@ psk_[1]   --> Extract --> ExpandWithLabel --> Extract = psk_secret_[2]
                  |                               |
                  V                               V
 psk_[n-1] --> Extract --> ExpandWithLabel --> Extract = psk_secret_[n]
-~~~~~
+~~~
 
 In particular, if there are no PreSharedKey proposals in a given Commit, then
 the resulting `psk_secret` is `psk_secret_[0]`, the all-zero vector.
@@ -2716,11 +2716,11 @@ The main MLS key schedule provides an `exporter_secret` which can
 be used by an application as the basis to derive new secrets called
 `exported_value` outside the MLS layer.
 
-~~~~~
+~~~
 MLS-Exporter(Label, Context, key_length) =
        ExpandWithLabel(DeriveSecret(exporter_secret, Label),
                          "exporter", Hash(Context), key_length)
-~~~~~
+~~~
 
 Each application SHOULD provide a unique label to `MLS-Exporter` that
 identifies its use case. This is to prevent two
@@ -2765,7 +2765,7 @@ tree.
 If N is a parent node in the Secret Tree then the secrets of the children of N
 are defined as follows (where left(N) and right(N) denote the children of N):
 
-~~~~
+~~~
 tree_node_[N]_secret
         |
         |
@@ -2774,13 +2774,13 @@ tree_node_[N]_secret
         |
         +--> ExpandWithLabel(., "tree", "right", KDF.Nh)
              = tree_node_[right(N)]_secret
-~~~~
+~~~
 
 The secret in the leaf of the Secret Tree is used to initiate two symmetric hash
 ratchets, from which a sequence of single-use keys and nonces are derived, as
 described in {{encryption-keys}}. The root of each ratchet is computed as:
 
-~~~~
+~~~
 tree_node_[N]_secret
         |
         |
@@ -2789,7 +2789,7 @@ tree_node_[N]_secret
         |
         +--> ExpandWithLabel(., "application", "", KDF.Nh)
              = application_ratchet_secret_[N]_[0]
-~~~~
+~~~
 
 ## Encryption Keys
 
@@ -2819,14 +2819,14 @@ Keys, nonces, and the secrets in ratchets are derived using
 DeriveTreeSecret. The context in a given call consists of the current position
 in the ratchet.
 
-~~~~~
+~~~
 DeriveTreeSecret(Secret, Label, Generation, Length) =
     ExpandWithLabel(Secret, Label, Generation, Length)
 
 Where Generation is encoded as a uint32.
-~~~~~
+~~~
 
-~~~~~
+~~~
 ratchet_secret_[N]_[j]
       |
       +--> DeriveTreeSecret(., "nonce", j, AEAD.Nn)
@@ -2838,7 +2838,7 @@ ratchet_secret_[N]_[j]
       V
 DeriveTreeSecret(., "secret", j, KDF.Nh)
 = ratchet_secret_[N]_[j+1]
-~~~~~
+~~~
 
 Here, AEAD.Nn and AEAD.Nk denote the lengths
 in bytes of the nonce and key for the AEAD scheme defined by
@@ -2931,7 +2931,7 @@ The signature is computed by the function `SignWithLabel` with a label
 `KeyPackage` and a content comprising of all of the fields except for the
 signature field.
 
-~~~~~
+~~~
 struct {
     ProtocolVersion version;
     CipherSuite cipher_suite;
@@ -2949,7 +2949,7 @@ struct {
     LeafNode leaf_node;
     Extension extensions<V>;
 } KeyPackageTBS;
-~~~~~
+~~~
 
 If a client receives a KeyPackage carried within an MLSMessage object, then it
 MUST verify that the `version` field of the KeyPackage has the same value as the
@@ -2996,9 +2996,9 @@ Within MLS, a KeyPackage is identified by its hash (see, e.g.,
 {{joining-via-welcome-message}}).  The `external_key_id` extension allows
 applications to add an explicit, application-defined identifier to a KeyPackage.
 
-~~~~~
+~~~
 opaque external_key_id<V>;
-~~~~~
+~~~
 
 # Group Creation
 
@@ -3058,12 +3058,12 @@ group.  At a minimum, all members of the group need to support the ciphersuite
 and protocol version in use.  Additional requirements can be imposed by
 including a `required_capabilities` extension in the GroupContext.
 
-~~~~~
+~~~
 struct {
     ExtensionType extension_types<V>;
     ProposalType proposal_types<V>;
 } RequiredCapabilities;
-~~~~~
+~~~
 
 This extension lists the extensions and proposal types that must be supported by
 all members of the group. The "default" proposal and extension types defined in this
@@ -3155,7 +3155,7 @@ a state transition occurs, the epoch number is incremented by one.
 Proposals are included in an MLSMessageContent by way of a Proposal structure
 that indicates their type:
 
-~~~~~
+~~~
 // See IANA registry for registered values
 uint16 ProposalType;
 
@@ -3172,7 +3172,7 @@ struct {
         case group_context_extensions: GroupContextExtensions;
     };
 } Proposal;
-~~~~~
+~~~
 
 On receiving an MLSMessageContent containing a Proposal, a client MUST verify the
 signature inside MLSMessageAuth.  If the signature verifies
@@ -3185,11 +3185,11 @@ An Add proposal requests that a client with a specified KeyPackage be added
 to the group.  The proposer of the Add MUST verify the validity of the
 KeyPackage, as specified in {{keypackage-validation}}.
 
-~~~~~
+~~~
 struct {
     KeyPackage key_package;
 } Add;
-~~~~~
+~~~
 
 An Add is applied after being included in a Commit message.  The position of the
 Add in the list of proposals determines the leaf node where the new member will
@@ -3217,11 +3217,11 @@ An Update proposal is a similar mechanism to Add with the distinction
 that it replaces the sender's LeafNode in the tree instead of adding a new leaf
 to the tree.
 
-~~~~~
+~~~
 struct {
     LeafNode leaf_node;
 } Update;
-~~~~~
+~~~
 
 A member of the group applies an Update message by taking the following steps:
 
@@ -3240,11 +3240,11 @@ A member of the group applies an Update message by taking the following steps:
 A Remove proposal requests that the member with LeafNodeRef `removed` be removed
 from the group.
 
-~~~~~
+~~~
 struct {
     LeafNodeRef removed;
 } Remove;
-~~~~~
+~~~
 
 A member of the group applies a Remove message by taking the following steps:
 
@@ -3265,11 +3265,11 @@ A member of the group applies a Remove message by taking the following steps:
 A PreSharedKey proposal can be used to request that a pre-shared key be
 injected into the key schedule in the process of advancing the epoch.
 
-~~~~~
+~~~
 struct {
     PreSharedKeyID psk;
 } PreSharedKey;
-~~~~~
+~~~
 
 The `psktype` of the pre-shared key MUST be `external` and the `psk_nonce` MUST
 be a randomly sampled nonce of length `KDF.Nh`. When processing a Commit message
@@ -3284,14 +3284,14 @@ parameters, for example, to increase the version number or to change the
 ciphersuite. The reinitialization is done by creating a completely new group
 and shutting down the old one.
 
-~~~~~
+~~~
 struct {
     opaque group_id<V>;
     ProtocolVersion version;
     CipherSuite cipher_suite;
     Extension extensions<V>;
 } ReInit;
-~~~~~
+~~~
 
 A member of the group applies a ReInit proposal by waiting for the committer to
 send the Welcome message that matches the ReInit, according to the criteria in
@@ -3308,11 +3308,11 @@ in the ReInit proposal MUST be no less than the version for the current group.
 An ExternalInit proposal is used by new members that want to join a group by
 using an external commit. This proposal can only be used in that context.
 
-~~~~
+~~~
 struct {
   opaque kem_output<V>;
 } ExternalInit;
-~~~~
+~~~
 
 A member of the group applies an ExternalInit message by initializing the next
 epoch using an init secret computed as described in {{external-initialization}}.
@@ -3325,7 +3325,7 @@ Though this information implies no change to the group, it is structured as a
 Proposal message so that it is included in the group's transcript by being
 included in Commit messages.
 
-~~~~~
+~~~
 struct {
     LeafNodeRef sender;
     uint32 first_generation;
@@ -3335,7 +3335,7 @@ struct {
 struct {
     MessageRange received_ranges<V>;
 } AppAck;
-~~~~~
+~~~
 
 An AppAck proposal represents a set of messages received by the sender in the
 current epoch.  Messages are represented by the `sender` and `generation` values
@@ -3445,7 +3445,7 @@ for previously sent proposals from anyone (including the committer) can be sent
 by reference.  Proposals sent by reference are specified by including the hash of
 the MLSPlaintext in which the proposal was sent (see {{hash-based-identifiers}}).
 
-~~~~~
+~~~
 enum {
   reserved(0),
   proposal(1)
@@ -3465,7 +3465,7 @@ struct {
     ProposalOrRef proposals<V>;
     optional<UpdatePath> path;
 } Commit;
-~~~~~
+~~~
 
 A group member that has observed one or more valid proposals within an epoch MUST send
 a Commit message before sending application data. This ensures, for example,
@@ -3535,7 +3535,7 @@ appearance of the updated member.
 In pseudocode, the logic for validating the `path` field of a Commit is as
 follows:
 
-~~~~~
+~~~
 pathRequiredTypes = [
     update,
     remove,
@@ -3554,7 +3554,7 @@ for i, id in commit.proposals:
 
 if len(commit.proposals) == 0 || pathRequired:
     assert(commit.path != null)
-~~~~~
+~~~
 
 To summarize, a Commit can have three different configurations, with different
 uses:
@@ -3828,11 +3828,11 @@ following information for the group's current epoch:
 In other words, to join a group via an External Commit, a new member needs a
 GroupInfo with an `ExternalPub` extension present in the `other_extensions`.
 
-~~~~~
+~~~
 struct {
     HPKEPublicKey external_pub;
 } ExternalPub;
-~~~~~
+~~~
 
 Thus, a member of the group can enable new clients to join by making a GroupInfo
 object available to them. Note that because a GroupInfo object is specific to an
@@ -3914,7 +3914,7 @@ If the sender of the Welcome message wants the receiving member to include a PSK
 in the derivation of the `epoch_secret`, they can populate the `psks` field
 indicating which PSK to use.
 
-~~~~~
+~~~
 struct {
   opaque path_secret<V>;
 } PathSecret;
@@ -3935,7 +3935,7 @@ struct {
   EncryptedGroupSecrets secrets<V>;
   opaque encrypted_group_info<V>;
 } Welcome;
-~~~~~
+~~~
 
 The client processing a Welcome message will need to have a copy of the group's
 ratchet tree.  The tree can be provided in the Welcome message, in an extension
@@ -3961,10 +3961,10 @@ On receiving a Welcome message, a client processes it using the following steps:
   the `welcome_key` and `welcome_nonce`. Use the key and nonce to decrypt the
   `encrypted_group_info` field.
 
-~~~~~
+~~~
 welcome_nonce = KDF.Expand(welcome_secret, "nonce", AEAD.Nn)
 welcome_key = KDF.Expand(welcome_secret, "key", AEAD.Nk)
-~~~~~
+~~~
 
 * Verify the signature on the GroupInfo object. The signature input comprises
   all of the fields in the GroupInfo object except the signature field. The
@@ -4038,7 +4038,7 @@ In cases where the application does not wish to provide such an external source,
 the whole public state of the ratchet tree can be provided in an extension of
 type `ratchet_tree`, containing a `ratchet_tree` object of the following form:
 
-~~~~~
+~~~
 enum {
     reserved(0),
     leaf(1),
@@ -4055,7 +4055,7 @@ struct {
 } Node;
 
 optional<Node> ratchet_tree<V>;
-~~~~~
+~~~
 
 The nodes are listed in the order specified by a left-to-right in-order
 traversal of the rachet tree. Each node is listed between its left subtree and
@@ -4069,7 +4069,7 @@ that 2^k is smaller than the length of the array. Intermediate parent nodes can
 be identified by performing the same calculation to the subarrays to the left
 and right of the root, following something like the following algorithm:
 
-~~~~~
+~~~
 # Assuming a class Node that has left and right members
 def subtree_root(nodes):
     # If there is only one node in the array return it
@@ -4089,7 +4089,7 @@ def subtree_root(nodes):
     root.left = subtree_root(nodes[:R])
     root.right = subtree_root(nodes[(R+1):])
     return root
-~~~~~
+~~~
 
 (Note that this is the same ordering of nodes as in the array-based tree representation
 described in {{array-based-trees}}.  The algorithms in that section may be used to
@@ -4099,7 +4099,7 @@ The example tree in {{ratchet-tree-terminology}} would be represented as an
 array of nodes in the following form, where R represents the "subtree root" for
 a given subarray of the node array:
 
-~~~~~
+~~~
               X
         ______|______
        /             \
@@ -4115,7 +4115,7 @@ A   B   C   D   E   F   G
 <-----------> R <------->
 <---> R <--->   <---> R -
 - R -   - R -   - R -
-~~~~~
+~~~
 
 The presence of a `ratchet_tree` extension in a GroupInfo message does not
 result in any changes to the GroupContext extensions for the group.  The ratchet
@@ -4770,7 +4770,7 @@ MLS DE, that MLS DE SHOULD defer to the judgment of the other MLS DEs.
 This document registers the "message/mls" MIME media type in order to allow other
 protocols (ex: HTTP {{!RFC7540}}) to convey MLS messages.
 
-~~~~~
+~~~
   Media type name: message
   Media subtype name: mls
   Required parameters: none
@@ -4789,7 +4789,7 @@ protocols (ex: HTTP {{!RFC7540}}) to convey MLS messages.
   Security considerations: MLS is an encrypted messaging layer designed
      to be transmitted over arbitrary lower layer protocols. The
      security considerations in this document (RFC XXXX) also apply.
-~~~~~
+~~~
 
 # Contributors
 
@@ -4893,7 +4893,7 @@ even-numbered nodes, with the n-th leaf at 2\*n.  Intermediate nodes
 are held in odd-numbered nodes.  For example, tree with 11 leaves has
 the following structure:
 
-~~~~~
+~~~
                                                    X
                            X
                X                       X                       X
@@ -4901,16 +4901,16 @@ the following structure:
       X     X     X     X     X     X     X     X     X     X     X
 Node: 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20
 Leaf: 0     1     2     3     4     5     6     7     8     9    10
-~~~~~
+~~~
 
 This allows us to compute relationships between tree nodes simply by
 manipulating indices, rather than having to maintain complicated structures in
 memory. The basic rule is that the high-order bits of parent and child nodes
 indices have the following relation (where `x` is an arbitrary bit string):
 
-~~~~~
+~~~
 parent=01x => left=00x, right=10x
-~~~~~
+~~~
 
 Since node relationships are implicit, the algorithms for adding and removing
 nodes at the right edge of the tree are quite simple:
@@ -4922,7 +4922,7 @@ nodes at the right edge of the tree are quite simple:
 The following python code demonstrates the tree computations necessary to use an
 array-based tree for MLS.
 
-~~~~~
+~~~
 # The exponent of the largest power of 2 less than x. Equivalent to:
 #   int(math.floor(math.log(x, 2)))
 def log2(x):
@@ -5056,7 +5056,7 @@ def common_ancestor_direct(x, y, _):
        xn, yn = xn >> 1, yn >> 1
        k += 1
     return (xn << k) + (1 << (k-1)) - 1
-~~~~~
+~~~
 
 
 # Link-Based Trees
@@ -5072,7 +5072,7 @@ or truncated when memebers are removed.
 The following code snippet shows how these algorithms could be implemented in
 Python.
 
-~~~~~
+~~~
 class Node:
     def __init__(self, value, parent=None, left=None, right=None):
         self.value = value    # Value of the node
@@ -5147,4 +5147,4 @@ class Tree:
         Q.right = X.parent.left
         Q.right.parent = Q
         return
-~~~~~
+~~~


### PR DESCRIPTION
A few changes to make code blocks a little more consistent / usable / pretty:

* Fence every code block with exactly three tildes
* Mark each code block with a type (`aasvg` / `ascii-art` / `pseudocode` / `tls` / `python`)

Marking with `aasvg` generates slightly prettier pictures for the ladder diagrams in the introduction.  Marking with `tls` makes it easy to programmatically extract the TLS syntax definitions in case we want to produce a syntax summary appendix like [the one TLS has](https://datatracker.ietf.org/doc/html/rfc8446#appendix-B), or in case implementers want to quickly get a listing of all the structs they need.  

The only substantive changes I made here were:

1. Removing the `ReInit` lines from the branch and re-inject PSK illustrations
2. Splitting pseudocode from TLS syntax in a few cases.