### PR TITLE
Add make target to extract TLS stanzas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,9 @@ endif
 
 fix-insecure-links:
 	sed -i'.bak' -e 's/http:/https:/g' draft-ietf-mls-protocol.html
+
+extract-tls:
+	cat draft-ietf-mls-protocol.md | python3 extract-tls.py > draft-ietf-mls-protocol.tls
+
+#extract-tls:
+#	cat draft-ietf-mls-protocol.md | python3 -c 'exec("""import sys, re\nmatch = False\nfor line in sys.stdin:\n if match:\n  if re.match("^~~~$", line):\n   match = False\n   print ("")\n  else:\n   print (line.rstrip())\n elif re.match("^~~~ tls$", line):\n  match = True\n""")' > draft-ietf-mls-protocol.tls

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,3 @@ fix-insecure-links:
 
 extract-tls:
 	cat draft-ietf-mls-protocol.md | python3 extract-tls.py > draft-ietf-mls-protocol.tls
-
-#extract-tls:
-#	cat draft-ietf-mls-protocol.md | python3 -c 'exec("""import sys, re\nmatch = False\nfor line in sys.stdin:\n if match:\n  if re.match("^~~~$", line):\n   match = False\n   print ("")\n  else:\n   print (line.rstrip())\n elif re.match("^~~~ tls$", line):\n  match = True\n""")' > draft-ietf-mls-protocol.tls

--- a/extract-tls.py
+++ b/extract-tls.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+import sys
+import re
+
+match = False
+
+for line in sys.stdin:
+	if match:
+		if re.match('^~~~$', line):
+			match = False
+			print ('')
+		else:
+			print (line.rstrip())
+	elif re.match('^~~~ tls$', line):
+		match = True


### PR DESCRIPTION
Added a short python program to extract the TLS presentation language stanzas into a single file.
Added extract-tls make target to run it.

An equivalent one liner option (only in the Makefile) is commented out.