### PR TITLE
Sub-group branching requires fresh key packages for each member

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -3145,7 +3145,7 @@ the referenced group.
 * The `version` and `ciphersuite` values in the Welcome MUST be the same as
   those used by the old group.
 * Each LeafNode in a new subgroup MUST match some LeafNode in the original
-  group. In this context, a pair of LeafNodes are said to "match" if the
+  group. In this context, a pair of LeafNodes is said to "match" if the
   identifiers presented by their respective credentials are considered
   equivalent by the application.
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -3128,9 +3128,15 @@ considered invalid.
 ## Sub-group Branching
 
 A new group can be formed from a subset of an existing group's members, using
-the same parameters as the old group.  The creator of the group indicates this
-situation by including a PreSharedKey of type `resumption` with usage `branch`
-in the Welcome message that creates the branched subgroup.
+the same parameters as the old group.  
+
+A member can create a sub-group by performing the following steps:
+
+1. Determine a subset of existing members that should be a part of the sub-group. 
+2. Create a new tree for the sub-group by fetching a new KeyPackage for each 
+   existing member that should be included in the sub-group.
+3. Create a Welcome message that includes a PreSharedKey of type `resumption` with 
+   usage `branch`.
 
 A client receiving a Welcome including a PreSharedKey of type `resumption` with
 usage `branch` MUST verify that the new group reflects a subgroup branched from

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -3144,8 +3144,10 @@ the referenced group.
 
 * The `version` and `ciphersuite` values in the Welcome MUST be the same as
   those used by the old group.
-* Each LeafNode in the new group's tree MUST be a leaf in the
-  old group's tree at the epoch indicated in the PreSharedKey.
+* Each LeafNode in a new subgroup MUST match some LeafNode in the original
+  group. In this context, a pair of LeafNodes are said to "match" if the
+  identifiers presented by their respective credentials are considered
+  equivalent by the application.
 
 In addition, to avoid key re-use, the `psk_nonce` included in the
 `PreSharedKeyID` object MUST be a randomly sampled nonce of length `KDF.Nh`.


### PR DESCRIPTION
Based on #623 , it should be made explicit that sub-group branching requires a fresh key package for each member. I think there is still a conflict of wording here that I would like feedback on because of this line (which is what triggered me thinking there was a bug)

```
Each LeafNode in the new group's tree MUST be a leaf in the old group's tree at the epoch indicated in the PreSharedKey
```