### PR TITLE
Ensure that a signature public key is always intelligible

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1251,7 +1251,7 @@ uncompressed Elliptic-Curve-Point-to-Octet-String conversion according to
 {{SECG}}.
 
 A Credential can provide multiple identifiers for the client.  It is up to the
-applciation to decide which identifier or identifiers to use at the application
+application to decide which identifier or identifiers to use at the application
 level.  For example,
 a certificate in an X509Credential may attest to several domain names or email
 addresses in its subjectAltName extension.  An application may decide to


### PR DESCRIPTION
This PR moves the signature key from `Credential` to `LeafNode`, to ensure that an MLS client always has a signature public key with which to verify messages, even if it does not support a member's credential type.

This is an alternative approach to #628, and IMO a bit cleaner.  We no longer need the notion of a SignatureScheme, since BasicCredential doesn't stand alone.  And since Credential only appears in LeafNode, common fields can be hoisted up into LeafNode. The Credential struct really only exists as a conceptual boundary, to make the exposition clearer; otherwise you could just shove the `select` into LeafNode.

Note that this does not obviate the need for #631.  This PR only ensures that the signatures can be processed; that PR helps ensure that the signatures are meaningful.