### PR TITLE
Be more precise about credential validation

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1354,6 +1354,8 @@ the AS.  In particular, at the following events in the protocol:
   for the member.
 * When a member receives a Commit with an UpdatePath whose LeafNode has a new
   credential for the committer.
+* When an `external_senders` extension is added to the group, or an existing
+  `external_senders` extension is updated.
 
 In cases where a member's credential is being replaced, such as Update and
 Commit cases above, the AS MUST also verify that the set of presented

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1218,6 +1218,10 @@ NIST curves (P-256, P-384, or P-521), the public key is the output of the
 uncompressed Elliptic-Curve-Point-to-Octet-String conversion according to
 {{SECG}}.
 
+The signatures used in this document are encoded as specified in {{!RFC8446}}.
+In particular, ECDSA signatures are DER-encoded and EdDSA signatures are defined
+as the concatenation of `r` and `s` as specified in {{?RFC8032}}.
+
 To disambiguate different signatures used in MLS, each signed value is prefixed
 by a label as shown below:
 
@@ -1321,18 +1325,41 @@ the issuer of the previous certificate.  The public key encoded in the
 `subjectPublicKeyInfo` of the end-entity certificate MUST be identical to the
 `signature_key` in the LeafNode containing this credential.
 
-The signatures used in this document are encoded as specified in {{!RFC8446}}.
-In particular, ECDSA signatures are DER-encoded and EdDSA signatures are defined
-as the concatenation of `r` and `s` as specified in {{?RFC8032}}.
+### Credential Validation
 
-Each new credential that has not already been validated by the application MUST
-be validated against the Authentication Service.  Applications SHOULD require
-that a client present the same set of identifiers throughout its presence in
-the group, even if its Credential is changed in a Commit or Update.  If an
-application allows clients to change identifiers over time, then each time the
-client presents a new credential, the application MUST verify that the set
-of identifiers in the credential is acceptable to the application for this
-client.
+The application using MLS is responsible for specifying which identifiers it
+finds acceptable for each member in a group.  In other words, following the
+model that {{?RFC6125}} describes for TLS, the application maintains a list of
+"reference identifiers" for the members of a group, and the credentials provide
+"presented identifiers".  A member of a group are authenticated by first
+validating that the member's credential legitimately represents some presented
+identifiers, and then ensuring that the reference identifiers for the member are
+authenticated by those presented identifiers.
+
+The parts of the system that perform these functions are collectively referred
+to as the Authentication Service (AS) {{?I-D.ietf-mls-architecture}}.  A
+member's credential is said to be _validated with the AS_ when the AS verifies
+the credential's presented identifiers, and verifies that those identifiers
+match the reference identifiers for the member.
+
+Whenever a new credential is introduced in the group, it MUST be validated with
+the AS.  In particular, at the following events in the protocol:
+
+* When a member receives a KeyPackage that it will use in an Add proposal to add
+  a new member to the group.
+* When a member receives a GroupInfo object that it will use to join a group,
+  either via a Welcome or via an external Commit
+* When a member receives an Add proposal adding a member to the group.
+* When a member receives an Update proposal whose LeafNode has a new credential
+  for the member.
+* When a member receives a Commit with an UpdatePath whose LeafNode has a new
+  credential for the committer.
+
+In cases where a member's credential is being replaced, such as Update and
+Commit cases above, the AS MUST also verify that the set of presented
+identifiers in the new credential is valid as a successor to the set of
+presented identifiers in the old credential, according to the application's
+policy.
 
 ### Uniquely Identifying Clients
 
@@ -1939,16 +1966,8 @@ The validity of a LeafNode needs to be verified at a few stages:
 
 The client verifies the validity of a LeafNode using the following steps:
 
-* Verify that the credential in the LeafNode is valid according to the
-  authentication service and the client's local policy. These actions MUST be
-  the same regardless of at what point in the protocol the LeafNode is being
-  verified with the following exception: If the LeafNode is an update to
-  another LeafNode, the authentication service MUST additionally validate that
-  the set of identities attested by the credential in the new LeafNode is
-  acceptable relative to the identities attested by the old credential.
-  For example:
-    * An Update proposal updates the sender's old LeafNode to a new one
-    * A "resync" external commit removes the joiner's old LeafNode via a Remove proposal and replaces it with a new one
+* Verify that the credential in the LeafNode is valid as described in
+  {{credential-validation}}.
 
 * Verify that the signature on the LeafNode is valid using `signature_key`.
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1331,7 +1331,7 @@ The application using MLS is responsible for specifying which identifiers it
 finds acceptable for each member in a group.  In other words, following the
 model that {{?RFC6125}} describes for TLS, the application maintains a list of
 "reference identifiers" for the members of a group, and the credentials provide
-"presented identifiers".  A member of a group are authenticated by first
+"presented identifiers".  A member of a group is authenticated by first
 validating that the member's credential legitimately represents some presented
 identifiers, and then ensuring that the reference identifiers for the member are
 authenticated by those presented identifiers.
@@ -1348,7 +1348,7 @@ the AS.  In particular, at the following events in the protocol:
 * When a member receives a KeyPackage that it will use in an Add proposal to add
   a new member to the group.
 * When a member receives a GroupInfo object that it will use to join a group,
-  either via a Welcome or via an external Commit
+  either via a Welcome or via an External Commit
 * When a member receives an Add proposal adding a member to the group.
 * When a member receives an Update proposal whose LeafNode has a new credential
   for the member.


### PR DESCRIPTION
Closes #678 
Replaces #660 

This PR attempts to add precision to the credential validation requirements in the document, along the lines @raphaelrobert suggests in #678, in the spirit of what @Bren2010 wrote up in #660 and drawing inspiration from what RFC 6125 does in the context of TLS.  It seems like this gives a clearer definition of (a) what the AS's job is and (b) when it needs to be done.