### PR TITLE
Clean up struct names and references to them

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -3903,11 +3903,7 @@ new members need information to bootstrap their local group state.
 ~~~ tls
 struct {
     CipherSuite cipher_suite;
-    opaque group_id<V>;
-    uint64 epoch;
-    opaque tree_hash<V>;
-    opaque confirmed_transcript_hash<V>;
-    Extension group_context_extensions<V>;
+    GroupContext group_context;
     Extension other_extensions<V>;
     MAC confirmation_tag;
     uint32 signer;

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1469,8 +1469,8 @@ struct {
 } MLSMessage;
 ~~~
 
-Proposals from senders external to the group are sent as MLSPlaintext. See
-{{external-proposals}} for more details.
+Messages from senders that aren't in the group are sent as MLSPlaintext. See
+{{external-proposals}} and {{joining-via-external-commits}} for more details.
 
 The following structure is used to fully describe the data transmitted in
 plaintexts or ciphertexts.
@@ -1579,7 +1579,7 @@ Recipients of an MLSMessage MUST verify the signature with the key depending on
 the `sender_type` of the sender as described above.
 
 The confirmation tag value confirms that the members of the group have arrived
-at the same state of the group. An ContentAuthData is said to be valid when both
+at the same state of the group. A ContentAuthData is said to be valid when both
 the `signature` and `confirmation_tag` fields are valid.
 
 ## Encoding and Decoding a Plaintext
@@ -3321,7 +3321,7 @@ a state transition occurs, the epoch number is incremented by one.
 
 ## Proposals
 
-Proposals are included in an MessageContent by way of a Proposal structure
+Proposals are included in a MessageContent by way of a Proposal structure
 that indicates their type:
 
 ~~~ tls
@@ -3342,7 +3342,7 @@ struct {
 } Proposal;
 ~~~
 
-On receiving an MessageContent containing a Proposal, a client MUST verify the
+On receiving a MessageContent containing a Proposal, a client MUST verify the
 signature inside ContentAuthData and that the `epoch` field of the enclosing
 MessageContent is equal to the `epoch` field of the current GroupContext object.
 If the verification is successful, then the Proposal should be cached in such a way
@@ -3763,7 +3763,7 @@ message at the same time, by taking the following steps:
   of PSKs in the derivation corresponds to the order of PreSharedKey proposals
   in the `proposals` vector.
 
-* Construct an MessageContent object containing the Commit object. Sign the
+* Construct a MessageContent object containing the Commit object. Sign the
   MessageContent using the old GroupContext as context.
   * Use the MessageContent to update the confirmed transcript hash and update
     the new GroupContext.
@@ -3921,7 +3921,7 @@ new members need information to bootstrap their local group state.
 struct {
     CipherSuite cipher_suite;
     GroupContext group_context;
-    Extension other_extensions<V>;
+    Extension extensions<V>;
     MAC confirmation_tag;
     uint32 signer;
     // SignWithLabel(., "GroupInfoTBS", GroupInfoTBS)

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -3954,13 +3954,8 @@ GroupInfo above `signature`:
 ~~~ tls
 struct {
     CipherSuite cipher_suite;
-    opaque group_id<V>;
-    uint64 epoch;
-    opaque tree_hash<V>;
-    opaque confirmed_transcript_hash<V>;
-    Extension group_context_extensions<V>;
-    Extension other_extensions<V>;
-    MAC confirmation_tag;
+    GroupContext group_context;
+    Extension extensions<V>;
     uint32 signer;
 } GroupInfoTBS;
 ~~~
@@ -3988,7 +3983,7 @@ following information for the group's current epoch:
 * external public key
 
 In other words, to join a group via an External Commit, a new member needs a
-GroupInfo with an `ExternalPub` extension present in the `other_extensions`.
+GroupInfo with an `ExternalPub` extension present in its `extensions` field.
 
 ~~~ tls
 struct {
@@ -4152,9 +4147,7 @@ welcome_key = KDF.Expand(welcome_secret, "key", AEAD.Nk)
   error.  Let `my_leaf` represent this leaf in the tree.
 
 * Construct a new group state using the information in the GroupInfo object.
-    * The GroupContext contains the `group_id`, `epoch`, `tree_hash`,
-      `confirmed_transcript_hash`, and `group_context_extensions` fields from
-      the GroupInfo object.
+    * The GroupContext is the `group_context` field from the GroupInfo object.
 
     * The new member's position in the tree is at the leaf `my_leaf`, as defined
       above.
@@ -4467,9 +4460,10 @@ In other words, an application can use GroupContext extensions to ensure that
 all members of the group agree on a set of parameters. Clients indicate their
 support for parameters in the `capabilities` field of their LeafNode. New
 members of a group are informed of the group's GroupContext extensions via the
-`group_context_extensions` field in the GroupInfo object. The `other_extensions`
-field in a GroupInfo object can be used to provide additional parameters to new
-joiners that are used to join the group.
+`extensions` field in the `group_context` field of the GroupInfo object. The
+`extensions` field in a GroupInfo object (outside of the `group_context` field)
+can be used to provide additional parameters to new joiners that are used to
+join the group.
 
 This extension mechanism is designed to allow for the secure and forward-compatible
 negotiation of extensions.  For this to work, implementations MUST correctly
@@ -4902,9 +4896,8 @@ Template:
 
   * KP: KeyPackage objects
   * LN: LeafNode objects
-  * GC: GroupContext objects (and the `group_context_extensions` field of
-    GroupInfo objects)
-  * GI: The `other_extensions` field of GroupInfo objects
+  * GC: GroupContext objects
+  * GI: GroupInfo objects
 
 * Recommended: Whether support for this extension is recommended by the IETF MLS
   WG.  Valid values are "Y" and "N".  The "Recommended" column is assigned a


### PR DESCRIPTION
Closes #673 
Closes #674 

With regard to #674: I searched for references to MLSPlaintext and Credential that were obsolete in light of the change to the MLSMessage framework.  (In particular, we used to have the idea that you would encode things as MLSPlaintext, then tranform them to MLSCiphertext if needed; now you encode to AuthenticatedContent and then convert that to MLSPlaintext/MLSCiphertext before sending.)  There were a few fixes for MLSPlaintext; I didn't find anything that needed fixing for Credentia, largely thanks to some PRs that have landed since I did the review that resulted in #674.