### PR TITLE
Improve parent hash guarantees

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2387,16 +2387,21 @@ Parent hashes are verified at two points in the protocol: When joining a group
 and when processing a Commit.
 
 The parent hash in a node U is valid with respect to a parent node P if the
-following criteria hold:
+following criteria hold.  Here C and S are the children of P (for "child" and
+"sibling"), with C being the child that is on the direct path of U (possibly U
+itself) and S the other child:
 
-* U is a descendant of P in the tree
-* The nodes between U and P in the tree are all blank
+* U is a descendant of P in the tree.
+
+* The resolution of C is equal to U added to the intersection of P's
+  `unmerged_leaves` with the subtree under C.
+
 * The `parent_hash` field of U is equal to the parent hash of P with copath
-  child S, where S is the child of P that is not on the path from U to P
-* The sibling of every node with a blank parent between U (included) and P
-  (excluded) has an empty resolution
-* `U.unmerged_leaves` is equal to the intersection between `P.unmerged_leaves`
-  and the leaves under U.
+  child S.
+
+These checks verify that U and P were updated at the same time (in the same
+UpdatePath), and that they were neighbors in the UpdatePath because the nodes in
+between them would have omitted from the filtered direct path.
 
 A parent node P is "parent-hash valid" if it can be chained back to a leaf node
 in this way.  That is, if there is leaf node L and a sequence of parent nodes
@@ -4111,16 +4116,15 @@ welcome_key = KDF.Expand(welcome_secret, "key", AEAD.Nk)
   * Verify that the tree hash of the ratchet tree matches the `tree_hash` field
     in GroupInfo.
 
-  * For each non-empty parent node, verify that exactly one of the node's
-    children are non-empty and have the hash of this node set as their
-    `parent_hash` value (if the child is another parent) or has a `parent_hash`
-    field in the LeafNode containing the same value (if the child is a
-    leaf). If either of the node's children is empty, and in particular does not
-    have a parent hash, then its respective children's `parent_hash` values have
-    to be considered instead.
+  * For each non-empty parent node, verify that it is "parent-hash valid",
+    as described in {{verifying-parent-hashes}}.
 
   * For each non-empty leaf node, validate the LeafNode as described in
     {{leaf-node-validation}}.
+
+  * For each non-empty parent node, verify that each entry in the node's
+    `unmerged_leaves` represents a non-blank leaf node that is a descendant of
+    the parent node.
 
 * Identify a leaf whose LeafNode is
   identical to the one in the KeyPackage.  If no such field exists, return an

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2393,8 +2393,8 @@ following criteria hold:
 * The nodes between U and P in the tree are all blank
 * The `parent_hash` field of U is equal to the parent hash of P with copath
   child S, where S is the child of P that is not on the path from U to P
-* The sibling of every node between U (included) and P (excluded) with a blank
-  parent has an empty resolution
+* The sibling of every node with a blank parent between U (included) and P
+  (excluded) has an empty resolution
 * `U.unmerged_leaves` is equal to the intersection between `P.unmerged_leaves`
   and the leaves under U.
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2392,7 +2392,11 @@ following criteria hold:
 * U is a descendant of P in the tree
 * The nodes between U and P in the tree are all blank
 * The `parent_hash` field of U is equal to the parent hash of P with copath
-  child S, where S is the child of P that is not on the path from U to P.
+  child S, where S is the child of P that is not on the path from U to P
+* The sibling of every node between U (included) and P (excluded) with a blank
+  parent has an empty resolution
+* `U.unmerged_leaves` is equal to the intersection between `P.unmerged_leaves`
+  and the leaves under U.
 
 A parent node P is "parent-hash valid" if it can be chained back to a leaf node
 in this way.  That is, if there is leaf node L and a sequence of parent nodes

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2393,11 +2393,11 @@ itself) and S the other child:
 
 * U is a descendant of P in the tree.
 
-* The resolution of C is equal to U added to the intersection of P's
-  `unmerged_leaves` with the subtree under C.
-
 * The `parent_hash` field of U is equal to the parent hash of P with copath
   child S.
+
+* U is in the resolution of C, and the intersection of P's `unmerged_leaves`
+  with the subtree under C is equal to the resolution of C with U removed.
 
 These checks verify that U and P were updated at the same time (in the same
 UpdatePath), and that they were neighbors in the UpdatePath because the nodes in


### PR DESCRIPTION
# A nice security property for parent-hash

The goal of #527 was to have a property similar to:

> If there is a parent-hash chain from the leaf L to a node N, then the signature of L binds the tree Canonicalize(N)

(where Canonicalize(N) is N with its unmerged leaves removed, i.e. the subtree of N the last time a Commit went through it)

However, this is currently not true, there are a few places where we can do (hopefully benign) modifications on N.

Example 1:
```
              W
        ______|_____
       /             \
      _               Y
    __|__           __|__
   /     \         /     \
  T       _       X       Z
 / \     / \     / \     / \
A   B   _   _   E   F   G   H
```

with the parent-hash chain A-T-W (happening with filtered update path).

We can modify the blank subtree:

```
              W
        ______|_____
       /             \
      _               Y
    __|__           __|__
   /     \         /     \
  T       V       X       Z
 / \     / \     / \     / \
A   B   C   D   E   F   G   H
```

and the parent-hash chain A-T-W is still valid

Example 2:

```
              W
        ______|_____
       /             \
      U               Y
    __|__           __|__
   /     \         /     \
  T       V       X       Z
 / \     / \     / \     / \
A   B   _   D   E   F   G   H
```

with the parent-hash chain A-T-U-W.

We can add unmerged leaves:

```
              W
        ______|_____
       /             \
      U[C]            Y
    __|__           __|__
   /     \         /     \
  T       V[C]    X       Z
 / \     / \     / \     / \
A   B   C   D   E   F   G   H
```

and the parent-hash chain A-T-U-W is still valid.

# How to get this property

These examples are not possible if we require the parent-hash check to verify other invariants that exists in MLS:
- if there is a parent-hash link from U to P and there are blank nodes between U and P, these blank nodes are here because of the filtered update path so their sibling have empty resolution (this invariant forbids example 1)
- if there is a parent-hash link from U to P, then there can't be a leaf which is merged for U but not for P, because U and P were last modified by a commit at the same time (this invariant forbids example 2)

This PR add these checks to the parent hash validation procedure.

# Proof that we do have the property with this PR

## Definitions

Un-adding leaves:
Let N be a node, and Ls a list of leaves.
Then UnAdd(N, Ls) is a tree identical to N, except that the leaves of Ls are blanked and removed from every node's unmerged leaves list.
Informally, this operation is the inverse of adding leaves Ls in N by participant not in N.

Canonicalization:
We define Canonicalize(N) = UnAdd(N, N.unmerged_leaves).

Tree equivalence:
We say T1 ~= T2 when Canonicalize(T1) = Canonicalize(T2).

Parent-hash link:
We say C ~> P when "the parent hash in a node C is valid with respect to a parent node P" as described in the "Verifying Parent Hashes" section (modified by this PR)

# Key property on ~= and ~>

We prove the following property:
If C ~> P
and C' ~> P'
and C ~= C'
then P ~= P'.

This is better understood with a nice square:
```
If we have:

C ~= C'
~    ~
V    V
P    P'

Then there is a ~= between P and P'
```

Proof of this property:

Let S (resp. S') be the sibling in the C ~> P (resp. C' ~> P') relation. Because leaf indices are inside the tree hash, S and S' are both on the same side of P and P'.

Fact 1: UnAdd(S, P.unmerged_leaves) = UnAdd(S', P'.unmerged_leaves).
Proof: By definition of the parent hash and injectivity of tree-hash.

Fact 2: UnAdd(C, P.unmerged_leaves) = UnAdd(C', P'.unmerged_leaves).
Proof:

```
  UnAdd(C, P.unmerged_leaves)
= UnAdd(C, Intersection(P.unmerged_leaves, Leaves(C))     by a simple lemma on UnAdd
= UnAdd(C, C.unmerged_leaves)                             by C ~> P (we use the second new invariant here!)
= UnAdd(C', C'.unmerged_leaves)                           by C ~= C'
= UnAdd(C', Intersection(P'.unmerged_leaves, Leaves(C'))) by C' ~> P' (we use the second new invariant here!)
= UnAdd(C', P'.unmerged_leaves)                           by a simple lemma on UnAdd
```

With Fact 1 and Fact 2, we deduce that P ~= P' (we use the first new invariant here!).

# Proof of signature binding

A leaf signature binds the existence of nodes Mi suh that L ~> M1 ~> ... ~> Mm = root

When there is a parent-hash-link path to a node P starting from a leaf L like L ~> N1 ~> ... ~> Nn ~> P, by applying inductively the property on ~= and ~> you get P ~= Mi for some i, hence L's signature binds Canonicalize(P) = Canonicalize(Mi).
