### PR TITLE
Require that unmerged_leaves be ordered

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1793,7 +1793,8 @@ The `encryption_key` field contains an HPKE public key whose private key is held
 by the members at the leaves among its descendants.  The `parent_hash` field
 contains a hash of this node's parent node, as described in {{parent-hash}}.
 The `unmerged_leaves` field lists the leaves under this parent node that are
-unmerged, according to their indices among all the leaves in the tree.
+unmerged, according to their indices among all the leaves in the tree.  The
+entries in the `unmerged_leaves` vector MUST be sorted in increasing order.
 
 ## Leaf Node Contents
 


### PR DESCRIPTION
While reviewing #713, I realized that we have a potential interop problem around `ParentNode.unmerged_leaves`.  This struct feeds into the tree hash, so everyone in the group needs to have the entries in the same order or else they'll disagree on the tree hash.  But the order isn't specified anywhere: All the document says right now is "add L's leaf index to the unmerged_leaves list", which could be implemented as an insert anywhere in the list.  This PR resolves the ambiguity by requiring the list be sorted.