### PR TITLE
Clarify tree hash and parent hash

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2244,7 +2244,8 @@ object, which may contain either a `LeafNodeHashInput` or a
 `ParentNodeHashInput` depending on the type of node. `LeafNodeHashInput` objects
 contain the `leaf_index` and the `LeafNode` (if any). `ParentNodeHashInput`
 objects contain the `ParentNode` (if any) and the tree hash of the node's left
-and right children.
+and right children.  For both parent and leaf nodes, the optional node value
+MUST be absent if the node is blank and present if the node contains a value.
 
 ~~~ tls
 enum {

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2422,22 +2422,22 @@ computation.
 
 ### Using Parent Hashes
 
-The Parent Hash of P appears in three types of structs. If V is itself a parent node
+The Parent Hash of P appears in three types of structs. If D is itself a parent node
 then P's Parent Hash is stored in the `parent_hash` field of the structs
 `ParentHashInput` and `ParentNode` of the node before P on the filtered direct
 path of U. (The `ParentNode` struct is used to encapsulate all public
 information about that node that must be conveyed to a new
 member joining the group as well as to define its Tree Hash.)
 
-If, on the other hand, V is the leaf L and its LeafNode has `leaf_node_source` set to `commit`,
-then the Parent Hash of P (with V's sibling as copath child) is stored in
+If, on the other hand, D is the leaf L and its LeafNode has `leaf_node_source` set to `commit`,
+then the Parent Hash of P (with D's sibling as copath child) is stored in
 the `parent_hash` field.  This is true in particular of the LeafNode object sent
 in the `leaf_node` field of an UpdatePath. The signature of such a LeafNode thus also
 attests to which keys the group member introduced into the ratchet tree and
 to whom the corresponding secret keys were sent. This helps prevent malicious insiders
-from constructing artificial ratchet trees with a node V whose HPKE secret key is
+from constructing artificial ratchet trees with a node D whose HPKE secret key is
 known to the insider yet where the insider isn't assigned a leaf in the subtree rooted
-at V. Indeed, such a ratchet tree would violate the tree invariant.
+at D. Indeed, such a ratchet tree would violate the tree invariant.
 
 ### Verifying Parent Hashes
 
@@ -5195,17 +5195,19 @@ we use the shorthand `ph` for parent hash, `th` for tree hash, and `osth` for
 original sibling tree hash):
 
 1. A adds B: set X
-  * `A.parent_hash = ph(X) = H(X, ph="", osth=th(B))`
+
+    * `A.parent_hash = ph(X) = H(X, ph="", osth=th(B))`
 
 2. B adds C, D: set B', X', Y
-  * `X'.parent_hash = ph(Y)  = H(Y, ph="", osth=th(Z))`,
-    where `th(Z)` covers `(C, _, D)`
-  * `B'.parent_hash = ph(X') = H(X', ph=X'.parent_hash, osth=th(A))`
+
+    * `X'.parent_hash = ph(Y)  = H(Y, ph="", osth=th(Z))`,
+      where `th(Z)` covers `(C, _, D)`
+    * `B'.parent_hash = ph(X') = H(X', ph=X'.parent_hash, osth=th(A))`
 
 3. C sends empty Commit: set C', Z', Y'
-  * `Z'.parent_hash = ph(Y') = H(Y', ph="", osth=th(X'))`, where
-    `th(X')` covers `(A, X', B')`
-  * `C'.parent_hash = ph(Z') = H(Z', ph=Z'.parent_hash, osth=th(D))`
+    * `Z'.parent_hash = ph(Y') = H(Y', ph="", osth=th(X'))`, where
+      `th(X')` covers `(A, X', B')`
+    * `C'.parent_hash = ph(Z') = H(Z', ph=Z'.parent_hash, osth=th(D))`
 
 When a new member joins, they will receive a tree that has the following parent
 hash values, and compute the indicated parent-hash validity relationships:

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1028,7 +1028,6 @@ in {{tree-hashes}}.
 
 The _resolution_ of a node is an ordered list of non-blank nodes
 that collectively cover all non-blank descendants of the node.  The resolution
-of a non-blank node with no unmerged leaves is just the node itself. More generally, the resolution
 of a node is effectively a depth-first, left-first enumeration of the nearest
 non-blank nodes below the node:
 
@@ -1108,7 +1107,7 @@ nodes are as follows:
 | B    | U, V, X     | A, W, Z  | U, X                 |
 | E    | Y, Z, X     | F, G, V  | Y, Z, X              |
 | F    | Y, Z, X     | E, G, V  | Y, Z, X              |
-| G    | U, V, X     | B, W, Z  | U, X                 |
+| G    | Z, X        | Y, V     | Z, X                 |
 
 ## Views of a Ratchet Tree {#views}
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -5031,7 +5031,7 @@ Since node relationships are implicit, the algorithms for adding and removing
 nodes at the right edge of the tree are quite simple.  If there are `N` nodes in
 the array:
 
-* Add: Append `N - 1` blank values to the end of the array.
+* Add: Append `N + 1` blank values to the end of the array.
 * Remove: Truncate the array to its first `(N-1) / 2` entries.
 
 The following python code demonstrates the tree computations necessary to use an

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2321,7 +2321,7 @@ effectively signs the subtree of the tree that hasn't been changed since that
 leaf was last changed in an UpdatePath.  A new member joining the group uses
 these parent hashes to verify that the parent nodes in the tree were set by
 members of the group, not chosen by an external attacker.  For an example of how
-this works, see {{th-ph-interaction}}.
+this works, see {{ph-evolution}}.
 
 Consider a ratchet tree with a non-blank parent node P and children D and S (for
 "parent", "direct path", and "sibling"), with D and P in the direct path of a
@@ -2339,7 +2339,7 @@ leaf node L (for "leaf"):
  /
 L
 ~~~
-
+{: #parent-hash-inputs title="Inputs to a parent hash." }
 
 The parent hash of P changes whenever an `UpdatePath` object is applied to
 the ratchet tree along a path from a leaf L traversing node D (and hence also
@@ -2423,22 +2423,20 @@ computation.
 
 ### Using Parent Hashes
 
-The Parent Hash of P appears in three types of structs. If D is itself a parent node
-then P's Parent Hash is stored in the `parent_hash` field of the structs
-`ParentHashInput` and `ParentNode` of the node before P on the filtered direct
-path of U. (The `ParentNode` struct is used to encapsulate all public
-information about that node that must be conveyed to a new
-member joining the group as well as to define its Tree Hash.)
+In ParentNode objects and LeafNode objects with `leaf_node_source` set to
+`commit`, the value of the `parent_hash` field is the parent hash of the next
+non-blank parent node above the node in question (the next node in the filtered
+direct path).  Using the node labels in {{parent-hash-inputs}}, the
+`parent_hash` field of D is equal to the parent hash of P with copath child S.
+This is the case even when the node D is a leaf node.
 
-If, on the other hand, D is the leaf L and its LeafNode has `leaf_node_source` set to `commit`,
-then the Parent Hash of P (with D's sibling as copath child) is stored in
-the `parent_hash` field.  This is true in particular of the LeafNode object sent
-in the `leaf_node` field of an UpdatePath. The signature of such a LeafNode thus also
-attests to which keys the group member introduced into the ratchet tree and
-to whom the corresponding secret keys were sent. This helps prevent malicious insiders
-from constructing artificial ratchet trees with a node D whose HPKE secret key is
-known to the insider yet where the insider isn't assigned a leaf in the subtree rooted
-at D. Indeed, such a ratchet tree would violate the tree invariant.
+The `parent_hash` field of a LeafNode is signed by the member.  The signature of
+such a LeafNode thus also attests to which keys the group member introduced into
+the ratchet tree and to whom the corresponding secret keys were sent. This
+prevents malicious insiders from constructing artificial ratchet trees with a
+node D whose HPKE secret key is known to the insider yet where the insider isn't
+assigned a leaf in the subtree rooted at D. Indeed, such a ratchet tree would
+violate the tree invariant.
 
 ### Verifying Parent Hashes
 
@@ -5170,10 +5168,10 @@ To construct the tree in {{parent-hash-tree}}:
 * E sends an empty Commit, setting Y and W
 * A adds a new member at F in a partial Commit, adding F as unmerged at Y and W
 
-# Interaction of Tree Hashes and Parent Hashes {#th-ph-interaction}
+# Evolution of Parent Hashes {#ph-evolution}
 
-To better understand how tree hashes and parent hashes interact, let's look in
-detail at how they evolve in a small group.  Consider the following sequence of
+To better understand how parent hashes are maintained, let's look in detail at
+how they evolve in a small group.  Consider the following sequence of
 operations:
 
 1. A initializes a new group

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2293,15 +2293,16 @@ which is computed recursively by starting at the leaf nodes and building up.
 ## Parent Hashes
 
 While tree hashes summarize the state of a tree at point in time, parent hashes
-capture information about how the tree was constructed.
+capture information about how keys in the tree were populated.
 
 When a client sends a commit to change a group, it can include an UpdatePath to
 assign new keys to the nodes along its filtered direct path.  When a client
 computes an UpdatePath (as defined in {{synchronizing-views-of-the-tree}}), it
 computes and signs a path hash that summarizes the state of the tree after the
 UpdatePath has been applied.  These summaries are constructed in a chain from
-the root to the member's leaf so that upper part of the chain can be overwritten
-as nodes set in one UpdatePath are reset by a later UpdatePath.
+the root to the member's leaf so that the part of the chain closer to the root
+can be overwritten as nodes set in one UpdatePath are reset by a later
+UpdatePath.
 
 ~~~ aasvg
                      ph(Q)
@@ -2316,11 +2317,11 @@ P.public_key --> ph(P)
 ~~~
 
 As a result, the signature over the parent hash in each member's leaf
-effectively signs the subtree containing the leaf for which that leaf was the
-last member to make a change.  A new member joining the group uses these parent
-hashes to verify that the parent nodes in the tree were set by members of the
-group, not chosen by an external attacker.  For an example of how this works,
-see {{th-ph-interaction}}.
+effectively signs the subtree of the tree that hasn't been changed since that
+leaf was last changed in an UpdatePath.  A new member joining the group uses
+these parent hashes to verify that the parent nodes in the tree were set by
+members of the group, not chosen by an external attacker.  For an example of how
+this works, see {{th-ph-interaction}}.
 
 Consider a ratchet tree with a non-blank parent node P and children D and S (for
 "parent", "direct path", and "sibling"), with D and P in the direct path of a

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2287,17 +2287,20 @@ indirectly includes information about the structure of the tree at the time the
 leaf node was last updated.
 
 Consider a ratchet tree with a non-blank parent node P and children D and S (for
-"parent", "direct path", and "sibling"):
+"parent", "direct path", and "sibling"), with D and P in the direct path of a
+leaf node L (for "leaf"):
 
 ~~~ ascii-art
-        ...
-        /
-       P
-     __|__
-    /     \
-   D       S
-  / \     / \
-... ... ... ...
+         ...
+         /
+        P
+      __|__
+     /     \
+    D       S
+   / \     / \
+ ... ... ... ...
+ /
+L
 ~~~
 
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -995,43 +995,6 @@ binary tree structure with these elements as leaves.
 used for the Merkle trees in the Certificate Transparency protocol
 {{?I-D.ietf-trans-rfc6962-bis}}.)
 
-The _direct path_ of a root is the empty list, and of any other node
-is the concatenation of that node's parent along with the parent's direct path.
-The _copath_ of a node is the node's sibling concatenated with the list of
-siblings of all the nodes in its direct path, excluding the root.
-
-For example, in the below tree:
-
-* The direct path of C is (W, V, X)
-* The copath of C is (D, U, Z)
-
-~~~ aasvg
-              X = root
-              |
-        .-----+-----.
-       /             \
-      V               Z
-      |               |
-    .-+-.           .-+
-   /     \         /   \
-  U       W       Y     +
- / \     / \     / \    |
-A   B   C   D   E   F   G
-
-0   1   2   3   4   5   6
-~~~
-{: #full-tree title="A complete tree with seven members" }
-
-A tree with `n` leaves has `2*n - 1` nodes.  For example, the above tree has 7
-leaves (A, B, C, D, E, F, G) and 13 nodes.
-
-Each leaf is given an _index_ (or _leaf index_), starting at `0` from the left to
-`n-1` at the right.
-
-Finally, a node in the tree may also be _blank_, indicating that no value
-is present at that node (i.e. no keying material). This is often the case
-when a leaf was recently removed from the tree.
-
 There are multiple ways that an implementation might represent a ratchet tree in
 memory.  For example, left-balanced binary trees can be represented as an array
 of nodes, with node relationships computed based on nodes' indices in the array.
@@ -1041,6 +1004,111 @@ implement the tree operations required for MLS in these representations.
 MLS places no requirements on implementations' internal representations
 of ratchet trees.  An implementation MAY use any tree representation and
 associated algorithms, as long as they produce correct protocol messages.
+
+### Ratchet Tree Nodes
+
+Each leaf node in a ratchet tree is given an _index_ (or _leaf index_), starting
+at `0` from the left to `n-1` at the right (for a tree with `n` leaves). A tree
+with `n` leaves has `2*n - 1` nodes, including parent nodes.
+
+Each node in a ratchet tree is either _blank_ (containing no value) or it holds
+an asymmetric key pair with some associated data:
+
+* A public key (for the HPKE scheme in use, see {{ciphersuites}})
+* A private key (only within the member's direct path, see {{views}})
+* A credential (only for leaf nodes)
+* An ordered list of "unmerged" leaves (see {{views}})
+* A hash of certain information about the node's parent, as of the last time the
+  node was changed (see {{parent-hash}}).
+
+Every node, regardless of whether the node is blank or populated, has
+a corresponding _hash_ that summarizes the contents of the subtree
+below that node.  The rules for computing these hashes are described
+in {{tree-hashes}}.
+
+The _resolution_ of a node is an ordered list of non-blank nodes
+that collectively cover all non-blank descendants of the node.  The resolution
+of a non-blank node with no unmerged leaves is just the node itself. More generally, the resolution
+of a node is effectively a depth-first, left-first enumeration of the nearest
+non-blank nodes below the node:
+
+* The resolution of a non-blank node comprises the node itself,
+  followed by its list of unmerged leaves, if any
+* The resolution of a blank leaf node is the empty list
+* The resolution of a blank intermediate node is the result of
+  concatenating the resolution of its left child with the resolution
+  of its right child, in that order
+
+For example, consider the following subtree, where the `_` character
+represents a blank node and unmerged leaves are indicated in square
+brackets:
+
+~~~ ascii-art
+       ...
+       /
+      _
+      |
+    .-+-.
+   /     \
+  _       Z[C]
+ / \     / \
+A   _   C   D
+
+0   1   2   3
+~~~
+{: #resolution-tree title="A tree with blanks and unmerged leaves" }
+
+In this tree, we can see all of the above rules in play:
+
+* The resolution of node Z is the list \[Z, C\]
+* The resolution of leaf 1 is the empty list \[\]
+* The resolution of top node is the list \[A, Z, C\]
+
+### Paths through a Ratchet Tree
+
+The _direct path_ of a root is the empty list, and of any other node
+is the concatenation of that node's parent along with the parent's direct path.
+
+The _copath_ of a node is the node's sibling concatenated with the list of
+siblings of all the nodes in its direct path, excluding the root.
+
+The _filtered direct path_ of a leaf node L is the node's direct path, with any
+node removed whose child on the copath of L has an empty resolution (keeping in
+mind that any unmerged leaves of the copath child count toward its resolution).
+The removed nodes do not need their own key pairs because encrypting to the
+nodes key pair would be equivalent to encrypting to its non-copath child.
+
+For example, consider the following tree (where blank nodes are indicated with
+`_`, but also assigned a label for reference):
+
+~~~ aasvg
+              X = root
+              |
+        .-----+-----.
+       /             \
+      _=V             Z
+      |               |
+    .-+-.           .-+
+   /     \         /   \
+  U       _=W     Y     +
+ / \     / \     / \    |
+A   B   _   _   E   F   G
+
+0   1   2   3   4   5   6
+~~~
+{: #full-tree title="A complete tree with seven members, with labels for blank
+parent nodes" }
+
+In this tree, the direct paths, copaths, and filtered direct paths for the leaf
+nodes are as follows:
+
+| Node | Direct path | Copath   | Filtered Direct Path |
+|:=====|:============|:=========|:=====================|
+| A    | U, V, X     | B, W, Z  | U, X                 |
+| B    | U, V, X     | A, W, Z  | U, X                 |
+| E    | Y, Z, X     | F, G, V  | Y, Z, X              |
+| F    | Y, Z, X     | E, G, V  | Y, Z, X              |
+| G    | U, V, X     | B, W, Z  | U, X                 |
 
 ## Views of a Ratchet Tree {#views}
 
@@ -1101,68 +1169,6 @@ A   ?   ?   ?     ?   B   ?   ?     ?   ?   C   ?     ?   ?   ?   D
 
 Note how the tree invariant applies: Each member knows only their own leaf, and
 the private key AB is known only to A and B.
-
-## Ratchet Tree Nodes
-
-A particular instance of a ratchet tree includes the same parameters that
-define an instance of HPKE, namely:
-
-* A Key Encapsulation Mechanism (KEM), including a `DeriveKeyPair` function that
-  creates a key pair for the KEM from a symmetric secret
-* A Key Derivation Function (KDF), including `Extract` and `Expand` functions
-* An AEAD encryption scheme
-
-Each non-blank node in a ratchet tree contains up to five values:
-
-* A public key
-* A private key (only within the member's direct path, see below)
-* A credential (only for leaf nodes)
-* An ordered list of "unmerged" leaves (see {{views}})
-* A hash of certain information about the node's parent, as of the last time the
-  node was changed (see {{parent-hash}}).
-
-The _resolution_ of a node is an ordered list of non-blank nodes
-that collectively cover all non-blank descendants of the node.  The resolution
-of a non-blank node with no unmerged leaves is just the node itself. More generally, the resolution
-of a node is effectively a depth-first, left-first enumeration of the nearest
-non-blank nodes below the node:
-
-* The resolution of a non-blank node comprises the node itself,
-  followed by its list of unmerged leaves, if any
-* The resolution of a blank leaf node is the empty list
-* The resolution of a blank intermediate node is the result of
-  concatenating the resolution of its left child with the resolution
-  of its right child, in that order
-
-For example, consider the following subtree, where the `_` character
-represents a blank node and unmerged leaves are indicated in square
-brackets:
-
-~~~ ascii-art
-       ...
-       /
-      _
-      |
-    .-+-.
-   /     \
-  _       Z[C]
- / \     / \
-A   _   C   D
-
-0   1   2   3
-~~~
-{: #resolution-tree title="A tree with blanks and unmerged leaves" }
-
-In this tree, we can see all of the above rules in play:
-
-* The resolution of node Z is the list \[Z, C\]
-* The resolution of leaf 1 is the empty list \[\]
-* The resolution of top node is the list \[A, Z, C\]
-
-Every node, regardless of whether the node is blank or populated, has
-a corresponding _hash_ that summarizes the contents of the subtree
-below that node.  The rules for computing these hashes are described
-in {{tree-hashes}}.
 
 # Cryptographic Objects
 
@@ -1986,15 +1992,7 @@ following procedure. The procedure is designed in a way that allows group member
 efficiently communicate the fresh secret keys to other group members, as
 described in {{update-paths}}.
 
-Recall the definition of resolution from {{ratchet-tree-nodes}}.
-To begin with, the generator of the UpdatePath updates its leaf and its leaf's
-_filtered direct path_ with new key pairs. The filtered direct path of a node
-is obtained from the node's direct path by removing all nodes whose child on
-the nodes' copath has an empty resolution (keeping in mind that any unmerged leaves of the copath
-child count towards its resolution). Such a removed node does not need its own key
-pair since, if the copath child's resolution is blank, then encrypting any data
-to the node's key pair would be equivalent to encrypting only to the
-non-copath child.
+A member updates the nodes along its direct path as follows:
 
 * Blank all the nodes on the direct path from the leaf to the root.
 * Generate a fresh HPKE key pair for the leaf.
@@ -2387,6 +2385,35 @@ recompute the expected value of `parent_hash` for the committer's new leaf and
 verify that it matches the `parent_hash` value in the supplied `leaf_node`.
 After being merged into the tree, the nodes in the UpdatePath form a parent-hash
 chain from the committer's leaf to the root.
+
+For example, nodes the tree in {{full-tree}} might have been populated by full
+Commits from A, E, F, G, and B (in that order).  These Commits would create the
+following parent-hash validity relationship (where the value for a node is reset
+each time it is listed):
+
+1. Commit from A: A -- U -- X
+2. Commit from E: E -- Y -- Z -- X
+3. Commit from F: F -- Y -- Z -- X
+4. Commit from G: G -- Z -- X
+5. Commit from B: B -- U -- X
+
+After these commits, the tree will have the following parent-hash chains:
+
+* A
+* B -- U -- X
+* E
+* F -- Y
+* G -- Z
+
+Since these chains collectively cover all non-blank parent nodes in the tree,
+the tree is parent-hash valid.
+
+Note that this tree, though valid, contains invalid parent-hash links. If a
+client were checking parent hashes top-down from X, for example, they would find
+that Z has an invalid parent hash relative to X, but that U has valid parent
+hash.  Likewise, if the client were checking bottom-up, they would find that the
+chain from F ends in an invalid link from Y to Z.  These invalid links are the
+natural result of multiple clients having committed.
 
 ## Update Paths
 
@@ -4926,7 +4953,9 @@ in this document.
 To construct the tree in {{full-tree}}:
 
 * A creates a group with B, ..., G
-* Each member sends an empty Commit setting its direct path
+* F sends an empty Commit, setting Y, Z, X
+* G removes C and D, blanking W, V, and setting Z, X
+* B sends an empty Commit, setting U and X
 
 To construct the tree in {{resolution-tree}}:
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2298,7 +2298,7 @@ capture information about how keys in the tree were populated.
 When a client sends a commit to change a group, it can include an UpdatePath to
 assign new keys to the nodes along its filtered direct path.  When a client
 computes an UpdatePath (as defined in {{synchronizing-views-of-the-tree}}), it
-computes and signs a path hash that summarizes the state of the tree after the
+computes and signs a parent hash that summarizes the state of the tree after the
 UpdatePath has been applied.  These summaries are constructed in a chain from
 the root to the member's leaf so that the part of the chain closer to the root
 can be overwritten as nodes set in one UpdatePath are reset by a later
@@ -2447,7 +2447,7 @@ The parent hash in a node D is valid with respect to a parent node P if the
 following criteria hold:
 
 * D is a descendant of P in the tree
-* The nodes between D and P in the tree are all blank
+* Any nodes between D and P in the tree are all blank
 * The `parent_hash` field of D is equal to the parent hash of P with copath
   child S, where S is the child of P that is not on the path from D to P.
 


### PR DESCRIPTION
Closes #655 

Depends on #694 
Conflicts with #713 

The diff here is messy because it includes #694.  The biggest change is the extended example, for which you can just scroll to the bottom.