### PR TITLE
Make git ignore the output of make extract-tls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ report.xml
 venv/
 lib
 draft-ietf-mls-protocol.xml
+draft-ietf-mls-protocol.tls


### PR DESCRIPTION
Currently `make extract-tls` generates a file with all the TLS Presentation Language structs. Add this file to `.gitignore`
