### PR TITLE
Fix resolution example

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1032,25 +1032,27 @@ represents a blank node and unmerged leaves are indicated in square
 brackets:
 
 ~~~ ascii-art
-       ...
-       /
-      _
-      |
-    .-+-.
-   /     \
-  _       Z[C]
- / \     / \
-A   _   C   D
+               ...
+               /
+              _
+        ______|______
+       /             \
+      X[C]            _
+    __|__           __|__
+   /     \         /     \
+  _       _       Y       _
+ / \     / \     / \     / \
+A   _   C   D   E   F   _   H
 
-0   1   2   3
+0   1   2   3   4   5   6   7
 ~~~
 {: #resolution-tree title="A tree with blanks and unmerged leaves" }
 
 In this tree, we can see all of the above rules in play:
 
-* The resolution of node Z is the list \[Z, C\]
-* The resolution of leaf 1 is the empty list \[\]
-* The resolution of top node is the list \[A, Z, C\]
+* The resolution of node X is the list \[X, C\]
+* The resolution of leaf 1 or leaf 6 is the empty list \[\]
+* The resolution of top node is the list \[X, C, Y, H\]
 
 ### Paths through a Ratchet Tree
 
@@ -5129,11 +5131,12 @@ To construct the tree in {{full-tree}}:
 
 To construct the tree in {{resolution-tree}}:
 
-* A creates a group with B, C, D, as well as some members outside this subtree
-* D removes C, setting Z and the top node (as well as any further nodes in the
-  direct path)
-* A member outside this subtree removes B, blanking B's direct path
-* A adds a new member at C with a partial Commit, adding it as unmerged at Z
+* A creates a group with B, ..., H, as well as some members outside this subtree
+* F sends an empty Commit, setting Y and its ancestors
+* D removes B, C, and F, with the following effects:
+  * Blank the direct paths of B, C, and G
+  * Set X, the top node, and any further nodes in the direct path of D
+* A adds a new member at C with a partial Commit, adding C as unmerged at X
 
 To construct the tree in {{evolution-tree}}:
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1037,12 +1037,12 @@ brackets:
               _
         ______|______
        /             \
-      X[C]            _
+      X[B]            _
     __|__           __|__
    /     \         /     \
   _       _       Y       _
  / \     / \     / \     / \
-A   _   C   D   E   F   _   H
+A   B   _   D   E   F   _   H
 
 0   1   2   3   4   5   6   7
 ~~~
@@ -1050,9 +1050,9 @@ A   _   C   D   E   F   _   H
 
 In this tree, we can see all of the above rules in play:
 
-* The resolution of node X is the list \[X, C\]
-* The resolution of leaf 1 or leaf 6 is the empty list \[\]
-* The resolution of top node is the list \[X, C, Y, H\]
+* The resolution of node X is the list \[X, B\]
+* The resolution of leaf 2 or leaf 6 is the empty list \[\]
+* The resolution of top node is the list \[X, B, Y, H\]
 
 ### Paths through a Ratchet Tree
 
@@ -5133,10 +5133,11 @@ To construct the tree in {{resolution-tree}}:
 
 * A creates a group with B, ..., H, as well as some members outside this subtree
 * F sends an empty Commit, setting Y and its ancestors
-* D removes B, C, and G, with the following effects:
-  * Blank the direct paths of B, C, and G
+* D removes B and C, with the following effects:
+  * Blank the direct paths of B and C
   * Set X, the top node, and any further nodes in the direct path of D
-* A adds a new member at C with a partial Commit, adding C as unmerged at X
+* Someone outside this subtree removes G, blanking the direct path of G
+* A adds a new member at B with a partial Commit, adding B as unmerged at X
 
 To construct the tree in {{evolution-tree}}:
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -5133,7 +5133,7 @@ To construct the tree in {{resolution-tree}}:
 
 * A creates a group with B, ..., H, as well as some members outside this subtree
 * F sends an empty Commit, setting Y and its ancestors
-* D removes B, C, and F, with the following effects:
+* D removes B, C, and G, with the following effects:
   * Blank the direct paths of B, C, and G
   * Set X, the top node, and any further nodes in the direct path of D
 * A adds a new member at C with a partial Commit, adding C as unmerged at X


### PR DESCRIPTION
The current resolution example tree can't be created by the protocol.  If C were not blank, then D would not populate Z in its filtered direct path.  (Note that this implies that there are never unmerged leaves at the first level of the tree.)  This PR expands the example tree so that it can have unmerged leaves while still having a blank top node.  This makes the example a little more complicated (you have to follow the recursion down two levels), but it doesn't seem too bad.