### PR TITLE
Add `external_senders` to MLS Extension Types registry

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -5002,6 +5002,7 @@ Initial contents:
 | 0x0002           | ratchet_tree             | GI         | Y           | RFC XXXX  |
 | 0x0003           | required_capabilities    | GC         | Y           | RFC XXXX  |
 | 0x0004           | external_pub             | GI         | Y           | RFC XXXX  |
+| 0x0005           | external_senders         | GC         | Y           | RFC XXXX  |
 | 0xff00  - 0xffff | Reserved for Private Use | N/A        | N/A         | RFC XXXX  |
 
 ## MLS Proposal Types


### PR DESCRIPTION
`external_senders` was missing from the Extension Types table so it didn't have an extension type value assigned