### PR TITLE
Fix GroupInfoTBS

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -4197,6 +4197,7 @@ GroupInfo above `signature`:
 struct {
     GroupContext group_context;
     Extension extensions<V>;
+    MAC confirmation_tag;
     uint32 signer;
 } GroupInfoTBS;
 ~~~


### PR DESCRIPTION
The `confirmation_tag` was missing. The error was introduced in #706.

This kind of error makes me wonder if the redundancy between the `...` and the `...TBS` really are necessary.

In my code, I use a pattern like this:
```
struct {
    GroupContext group_context;
    Extension extensions<V>;
    MAC confirmation_tag;
    uint32 signer;
} GroupInfoTBS;

struct {
    GroupInfoTBS tbs;
    // SignWithLabel(., "GroupInfoTBS", GroupInfoTBS)
    opaque signature<V>;
} GroupInfo;
```

No copy-paste error possible! Looks a bit weird, but if we replace "tbs" by "data", it makes more sense.