### PR TITLE
Include leaf index in LeafNodeTBS for better parent-hash guarantees

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2005,9 +2005,11 @@ struct {
 
         case update:
             opaque group_id<V>;
+            uint32 leaf_index;
 
         case commit:
             opaque group_id<V>;
+            uint32 leaf_index;
     }
 } LeafNodeTBS;
 ~~~


### PR DESCRIPTION
# A problem in parent-hash proofs

The goal of #527 and #713 was to have a property similar to:

> If there is a parent-hash chain from the leaf L to a node N, then the signature of L binds the tree Canonicalize(N)

In #713, I proved that the pull-request allowed to prove the following property:

> If Canonicalize(U1) = Canonicalize(U2),
> and there is a parent-hash link from U1 to P1 and from U2 to P2,
> then Canonicalize(P1) = Canonicalize(P2)

With this property, the hope is to inductively show that the leaf signature binds the canonicalization of subtrees it is parent-hash linked from.
The induction step works fine thanks to the previous theorem, however the base case is wrong.

The hypothesis "Canonicalize(U1) = Canonicalize(U2)" says that the content of the trees are equal, and also says they have the same location (i.e. they have the same node index). This is important for the induction step.
However, since the signature of a leaf doesn't bind its position in the tree, we can't initialize the induction.

This PR resolves this problem.

# A concrete counter-example

Assume we have the following tree:

          Y
        __|__
       /     \
      _       Z
     / \     / \
    A   _   C   D

If there is a parent-hash link from A to Y, then the following tree is also valid:

          Y
        __|__
       /     \
      _       Z
     / \     / \
    _   A   C   D
    
# The solution

We only need to add the leaf index inside the signature when the source is a commit.
I also added it in the update case because it doesn't hurt, but that's not necessary.