### PR TITLE
Simplify Remove section

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -3601,10 +3601,7 @@ leaf node.
 
 A member of the group applies a Remove message by taking the following steps:
 
-* Identify a leaf node matching `removed`.  This lookup MUST be done on the tree
-  before any non-Remove proposals have been applied (the "old" tree in the
-  terminology of {{commit}}), since proposals such as Update can change the
-  LeafNode stored at a leaf.  Let L be this leaf node.
+* Identify the leaf node matching `removed`.  Let L be this leaf node.
 
 * Replace the leaf node L with a blank node
 


### PR DESCRIPTION
The part about doing the lookup in the old tree was added in #491, it was relevant here because of the hash references.
This is not a problem anymore since we came back to referencing with leaf index.