### PR TITLE
Change to external_pub

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -4380,7 +4380,7 @@ following information for the group's current epoch:
 * external public key
 
 In other words, to join a group via an External Commit, a new member needs a
-GroupInfo with an `ExternalPub` extension present in its `extensions` field.
+GroupInfo with an `external_pub` extension present in its `extensions` field.
 
 ~~~ tls
 struct {


### PR DESCRIPTION
For consistency with references to other extensions (and with the IANA registry), refer to the extension as "external_pub".