### PR TITLE
Use C-style comments in TLS presentation syntax

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1656,12 +1656,14 @@ struct {
 opaque MAC<V>;
 
 struct {
-    // SignWithLabel(., "MLSContentTBS", MLSContentTBS)
+    /* SignWithLabel(., "MLSContentTBS", MLSContentTBS) */
     opaque signature<V>;
     select (MLSContent.content_type) {
         case commit:
-            // MAC(confirmation_key,
-            //     GroupContext.confirmed_transcript_hash)
+            /*
+              MAC(confirmation_key,
+                  GroupContext.confirmed_transcript_hash)
+            */
             MAC confirmation_tag;
         case application:
         case proposal:
@@ -1975,7 +1977,7 @@ struct {
     }
 
     Extension extensions<V>;
-    // SignWithLabel(., "LeafNodeTBS", LeafNodeTBS)
+    /* SignWithLabel(., "LeafNodeTBS", LeafNodeTBS) */
     opaque signature<V>;
 } LeafNode;
 
@@ -2863,7 +2865,7 @@ transcript hash.
 ~~~ tls
 struct {
     WireFormat wire_format;
-    MLSContent content; // with content.content_type == commit
+    MLSContent content; /* with content_type == commit */
     opaque signature<V>;
 } ConfirmedTranscriptHashInput;
 
@@ -2873,7 +2875,7 @@ struct {
 ~~~
 
 ~~~ pseudocode
-interim_transcript_hash_[0] = ""; // zero-length octet string
+interim_transcript_hash_[0] = ""; /* zero-length octet string */
 
 confirmed_transcript_hash_[n] =
     Hash(interim_transcript_hash_[n] ||
@@ -3288,7 +3290,7 @@ struct {
     HPKEPublicKey init_key;
     LeafNode leaf_node;
     Extension extensions<V>;
-    // SignWithLabel(., "KeyPackageTBS", KeyPackageTBS)
+    /* SignWithLabel(., "KeyPackageTBS", KeyPackageTBS) */
     opaque signature<V>;
 } KeyPackage;
 
@@ -4180,7 +4182,7 @@ struct {
     Extension extensions<V>;
     MAC confirmation_tag;
     uint32 signer;
-    // SignWithLabel(., "GroupInfoTBS", GroupInfoTBS)
+    /* SignWithLabel(., "GroupInfoTBS", GroupInfoTBS) */
     opaque signature<V>;
 } GroupInfo;
 ~~~


### PR DESCRIPTION
Fixes #742 