### PR TITLE
Remove the `unmerged_leaves` array from parent nodes

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2670,10 +2670,17 @@ UpdatePath), and that they were neighbors in the UpdatePath because the nodes in
 between them would have omitted from the filtered direct path.
 
 A parent node P is "parent-hash valid" if it can be chained back to a leaf node
-in this way.  That is, if there is leaf node L and a sequence of parent nodes
-P\_1, ..., P\_N such that P\_N = P and each step in the chain is authenticated
-by a parent hash: L's parent hash is valid with respect to P\_1, P\_1's parent
-hash is valid with respect to P\_2, and so on.
+in this way, and if that leaf node was the last updated leaf under that parent
+node.  That is, P is parent-hash valid if:
+
+1. There is leaf node L and a sequence of parent nodes P\_1, ..., P\_N such that
+   P\_N = P and each step in the chain is authenticated by a parent hash: L's
+   parent hash is valid with respect to P\_1, P\_1's parent hash is valid with
+   respect to P\_2, and so on.
+
+2. The leaf node L has `leaf_node_source` set to `commit` and its `commit_epoch`
+   field indicates a epoch greater than or equal to any `update_epoch` or
+   `commit_epoch` value present among the leaf nodes that are descendants of P.
 
 When joining a group, the new member MUST authenticate that each non-blank
 parent node P is parent-hash valid.  This can be done "bottom up" by building

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1114,18 +1114,27 @@ below that node.  The rules for computing these hashes are described
 in {{tree-hashes}}.
 
 Nodes also have a corresponding _last update epoch_, which corresponds to the
-epoch in which their content was last modified.  For non-blank leaves, this last
-update epoch is stored in their content (if their source is an update or commit).
-For non-blank nodes, the last update epoch is the last epoch at which one of its
-leaves was updated, in other words it is the maximum last update epoch of its
-leaves.
+epoch in which their content was last modified:
+
+* The last update epoch of a non-blank leaf L with `L.leaf_node_source == commit`
+  is equal to `L.commit_epoch`
+* The last update epoch of a blank leaf, or a non-blank L with
+  `L.leaf_node_source == key_package` or `L.leaf_node_source == update` is equal
+  to `0`
+* The last update epoch of an intermediate node is the maximum between the last
+  update epoch of its left child and the last update epoch of its right child
 
 A leaf can be added under a node's subtree after this node was last updated,
 in that case we say that this leaf is _unmerged_ for this node.  More precisely,
-a leaf is unmerged for a node iff. its source is key package and its add epoch
-is greater or equal than the last update epoch of the node. The list of leaves
-that are unmerged for a node is called the list of _unmerged leaves_ for this
-node.
+a leaf L is unmerged for a node P when:
+
+* P is an ancestor of L
+* `L.leaf_node_source == key_package`
+* `L.add_epoch >= LastUpdateEpoch(P)`, where `LastUpdateEpoch(P)` is the last
+  update epoch of `P`, as computed above
+
+The list of leaves that are unmerged for a node is called the list of
+_unmerged leaves_ for this node.
 
 The _resolution_ of a node is an ordered list of non-blank nodes
 that collectively cover all non-blank descendants of the node.  The resolution

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1971,9 +1971,10 @@ struct {
             Lifetime lifetime;
 
         case update:
-            struct{};
+            uint64 update_epoch;
 
         case commit:
+            uint64 commit_epoch;
             opaque parent_hash<V>;
     };
 
@@ -1994,9 +1995,10 @@ struct {
             Lifetime lifetime;
 
         case update:
-            struct{};
+            uint64 update_epoch;
 
         case commit:
+            uint64 commit_epoch;
             opaque parent_hash<V>;
     };
 
@@ -2108,9 +2110,12 @@ The client verifies the validity of a LeafNode using the following steps:
   * If the LeafNode appears in a KeyPackage, verify that `leaf_node_source` is
     set to `key_package`.
   * If the LeafNode appears in an Update proposal, verify that `leaf_node_source`
-    is set to `update`.
+    is set to `update` and `update_epoch` is set to the current epoch.
   * If the LeafNode appears in the `leaf_node` value of the UpdatePath in
-    a Commit, verify that `leaf_node_source` is set to `commit`.
+    a Commit, verify that `leaf_node_source` is set to `commit`  and
+    `commit_epoch` is set to the current epoch.
+  * If the LeafNode appears in a ratchet tree, verify that the `update_epoch`
+    or `commit_epoch` fields, if present, indicate an epoch before the current epoch.
 
 * Verify that the following fields are unique among the members of the group:
     * `signature_key`

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2638,8 +2638,8 @@ Note that no recomputation is needed if the tree hash of S is unchanged since
 the last time P was updated. This is the case for computing or processing a
 Commit whose UpdatePath traverses P, since the Commit itself resets P. (In
 other words, it is only necessary to recompute the original sibling tree hash
-when validating a group's tree on joining.) More generally, if no unmerged leaf
-of P under S (and thus no leaves were blanked),
+when validating a group's tree on joining.) More generally, if no leaf under S
+is unmerged with regard to P (and thus no leaves were blanked),
 then the original tree hash at S is the tree hash of S in the current tree.
 
 If it is necessary to recompute the original tree hash of a node, the efficiency

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1143,7 +1143,7 @@ of a node is effectively a depth-first, left-first enumeration of the nearest
 non-blank nodes below the node:
 
 * The resolution of a non-blank node comprises the node itself,
-  followed by its list of unmerged leaves, if any
+  followed by its list of unmerged leaves (ordered from left to right), if any
 * The resolution of a blank leaf node is the empty list
 * The resolution of a blank intermediate node is the result of
   concatenating the resolution of its left child with the resolution

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1123,8 +1123,9 @@ leaves.
 A leaf can be added under a node's subtree after this node was last updated,
 in that case we say that this leaf is _unmerged_ for this node.  More precisely,
 a leaf is unmerged for a node iff. its source is key package and its add epoch
-is greater than the last update epoch of the node. The list of leaves that are
-unmerged for a node is called the list of _unmerged leaves_ for this node.
+is greater or equal than the last update epoch of the node. The list of leaves
+that are unmerged for a node is called the list of _unmerged leaves_ for this
+node.
 
 The _resolution_ of a node is an ordered list of non-blank nodes
 that collectively cover all non-blank descendants of the node.  The resolution

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1981,7 +1981,6 @@ struct {
     LeafNodeSource leaf_node_source;
     select (LeafNode.leaf_node_source) {
         case key_package:
-            uint64 add_epoch;
             Lifetime lifetime;
 
         case update:
@@ -1995,6 +1994,14 @@ struct {
     Extension extensions<V>;
     /* SignWithLabel(., "LeafNodeTBS", LeafNodeTBS) */
     opaque signature<V>;
+    /* add_epoch is not authenticated */
+    select (LeafNode.leaf_node_source) {
+        case key_package:
+            uint64 add_epoch;
+        case update:
+        case commit:
+            struct{};
+    };
 } LeafNode;
 
 struct {
@@ -2006,7 +2013,6 @@ struct {
     LeafNodeSource leaf_node_source;
     select (LeafNodeTBS.leaf_node_source) {
         case key_package:
-            /* add_epoch is not authenticated */
             Lifetime lifetime;
 
         case update:

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2671,7 +2671,7 @@ between them would have omitted from the filtered direct path.
 
 A parent node P is "parent-hash valid" if it can be chained back to a leaf node
 in this way, and if that leaf node was the last updated leaf under that parent
-node.  That is, P is parent-hash valid if:
+node.  That is, P is parent-hash valid if all of the following hold:
 
 1. There is leaf node L and a sequence of parent nodes P\_1, ..., P\_N such that
    P\_N = P and each step in the chain is authenticated by a parent hash: L's

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1118,9 +1118,10 @@ epoch in which their content was last modified:
 
 * The last update epoch of a non-blank leaf L with `L.leaf_node_source == commit`
   is equal to `L.commit_epoch`
+* The last update epoch of a non-blank leaf L with `L.leaf_node_source == update`
+  is equal to `L.update_epoch`
 * The last update epoch of a blank leaf, or a non-blank L with
-  `L.leaf_node_source == key_package` or `L.leaf_node_source == update` is equal
-  to `0`
+  `L.leaf_node_source == key_package` is equal to `0`
 * The last update epoch of an intermediate node is the maximum between the last
   update epoch of its left child and the last update epoch of its right child
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1104,7 +1104,7 @@ an asymmetric key pair with some associated data:
 Moreover, leaf nodes contains:
 * A credential and signature verification key
 * A source, telling how the leaf node was introduced in the tree (see
-  {{#leaf-node-contents}})
+  {{leaf-node-contents}})
 * An epoch at which it was added (if the source is a key package) or at
   which it was last updated (if the source is an update or commit).
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1116,12 +1116,9 @@ in {{tree-hashes}}.
 Nodes also have a corresponding _last update epoch_, which corresponds to the
 epoch in which their content was last modified:
 
-* The last update epoch of a non-blank leaf L with `L.leaf_node_source == commit`
+* The last commit epoch of a non-blank leaf L with `L.leaf_node_source == commit`
   is equal to `L.commit_epoch`
-* The last update epoch of a non-blank leaf L with `L.leaf_node_source == update`
-  is equal to `L.update_epoch`
-* The last update epoch of a blank leaf, or a non-blank L with
-  `L.leaf_node_source == key_package` is equal to `0`
+* The last commit epoch of other leaves are equal to 0
 * The last update epoch of an intermediate node is the maximum between the last
   update epoch of its left child and the last update epoch of its right child
 
@@ -2145,7 +2142,7 @@ The client verifies the validity of a LeafNode using the following steps:
     is set to `update` and `update_epoch` is set to the current epoch.
   * If the LeafNode appears in the `leaf_node` value of the UpdatePath in
     a Commit, verify that `leaf_node_source` is set to `commit`  and
-    `commit_epoch` is set to the current epoch.
+    `commit_epoch` is set to the new epoch.
   * If the LeafNode appears in a ratchet tree, verify that the `update_epoch`
     or `commit_epoch` fields, if present, indicate an epoch before the current epoch.
 
@@ -2691,10 +2688,10 @@ itself) and S the other child:
 * The `parent_hash` field of D is equal to the parent hash of P with copath
   child S.
 
-* The last update epoch of D is equal to the last update epoch of P
+* The last update epoch of D is equal to the last update epoch of P.
 
-* The nodes between D and P are blank, and the resolution of nodes on the copath
-  from D to P are a subset of unmerged leaves of P
+* D is in the resolution of C, and nodes in the resolution of C are either equal
+  to D or are unmerged leaves of P.
 
 These checks verify that D and P were updated at the same time (in the same
 UpdatePath), and that they were neighbors in the UpdatePath because the nodes in

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -4335,6 +4335,10 @@ welcome_key = KDF.Expand(welcome_secret, "key", AEAD.Nk)
   * For each non-empty leaf node, validate the LeafNode as described in
     {{leaf-node-validation}}.
 
+  * For each non-empty leaf node, verify that its add epoch, update epoch or
+    commit epoch (depending on the source) is less than or equal to the group
+    epoch.
+
 * Identify a leaf whose LeafNode is
   identical to the one in the KeyPackage.  If no such field exists, return an
   error.  Let `my_leaf` represent this leaf in the tree.


### PR DESCRIPTION
This PR builds on #751, and goes one step further: now the add epoch is also stored in leaf nodes whose source is KeyPackage.

One nice benefit of this is that there is no need for the `unmerged_leaves` array anymore: it can be re-computed only from the epoch information in the leaves.

Indeed, define the LastUpdateEpoch(N) as `max { L.last_update_epoch | L.source = commit and L is in N's subtree }`.
Then we have the following invariant on the unmerged leaves array: for every non-blank node N and leaves L: L is in N.unmerged_leaves iff. L.source = key_package and L.add_epoch >= LastUpdateEpoch(N).

<details><summary>Proof sketch / explanations why it is true</summary>

> The first invariant is an epoch invariant: at any time, the add / update / commit epoch of leaves is less than or equal to the current epoch.
> 
> Then we prove the unmerged leaves invariant by checking every "atomic" operation on the tree, as it was done in [the parent-hash correctness proof in the past](https://github.com/mlswg/mls-protocol/pull/527#issuecomment-1035122916).
> 
> Addition of a new leaf L:
> By the epoch invariant, the add epoch of L greater or equal than the commit epoch of any leaf of the tree, hence it is greater or equal than LastUpdateEpoch(N) of every non-blank node N on the path from L to the root and is unmerged for these nodes
> 
> Removal of a leaf L:
> Every non-blank node N that is not blanked by the removal of L doesn't contain L, hence the invariant is preserved.
> 
> UpdatePath from a leaf L:
> By the epoch invariant, the commit epoch of L is strictly greater than the epoch of any leaf of the tree (because it is equal to the current epoch, plus one)
> Hence for every node N on the path from L to the root, LastUpdateEpoch(N) = commit epoch of L, hence no leaf is unmerged for N.
> 
> Update of a leaf L:
> Roughly the same as removal
> 
> Truncation / extension:
> nothing to say

</details>

This means that we can remove this array, while still conserving the notion of unmerged leaves, using the above equivalence as the new definition for unmerged leaves.

I think this greatly simplifies the protocol:
- now it is crystal clear that unmerged leaves corresponds to node that were added after the node was last updated (it's their definition!)
- the "original tree hash" thing is much easier to explain and understand: no need to explain that we modify the unmerged leaves array
- a lot of invariants of unmerged leaves comes "for free", such as the invariants we added in #713: with this definition, unmerged leaves of a node are automatically non-blank leaves in that node's subtree
- even better: this gives even more invariants for unmerged leaves, including one that is crucial for the correctness of the O(n log log n) tree verification procedure described in #527 (discussed in the review of cisco/mlspp#289). The invariant is the following: given and descent D and a parent P, if a leaf L under D's subtree is unmerged for P, then it is unmerged for D. This invariant (that is not currently checked by MLS when joining a group) comes for free, simply because LastUpdateEpoch(P) >= LastUpdateEpoch(D).

I think this PR is not hard to implement:
- the LastUpdateEpoch thing can be memoized as it is done with TreeHash
- in fact implementations can keep the unmerged leaves array in parent nodes, to memoize the unmerged leaves of every node, but now it's just an implementation trick and not some book-keeping hardcoded inside the protocol

I think this PR doesn't introduce any problem in security proofs: although we introduce a non-authenticated field (the add epoch of new leaves), it actually correspond to the fact that the unmerged leaves of a node N is not authenticated by one of its leaves via parent-hash.
Of course, "I think" is not enough and if we agree that it's a mergeable PR on the only condition that we have security proofs for this PR, I'd be very happy to update my proofs (which should be soon published).