### PR TITLE
BasicCredential public key must be same as in LeafNode

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1401,6 +1401,8 @@ struct {
 
 A BasicCredential is a bare assertion of an identity, without any additional
 information.  The format of the encoded identity is defined by the application.
+Public key material associated with the BasicCredential MUST be identical to the
+`signature_key` in the LeafNode containing this credential.
 
 For an X.509 credential, each entry in the chain represents a single DER-encoded
 X.509 certificate. The chain is ordered such that the first entry (chain[0]) is


### PR DESCRIPTION
Unless I'm missing something there's currently no connection between the basic credential and the signature public key in the leaf node. A sentence similar to the x.509 option should be added.