### PR TITLE
Update table header dividers

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1196,7 +1196,7 @@ In this tree, the direct paths, copaths, and filtered direct paths for the leaf
 nodes are as follows:
 
 | Node | Direct path | Copath   | Filtered Direct Path |
-|:=====|:============|:=========|:=====================|
+|:-----|:------------|:---------|:---------------------|
 | A    | T, U, W     | B, V, Y  | T, W                 |
 | B    | T, U, W     | A, V, Y  | T, W                 |
 | E    | X, Y, W     | F, Z, U  | X, Y, W              |
@@ -5388,7 +5388,7 @@ When a new member joins, they will receive a tree that has the following parent
 hash values, and compute the indicated parent-hash validity relationships:
 
 | Node | Parent hash value                    | Valid?              |
-|:=====|:=====================================|:====================|
+|:-----|:-------------------------------------|:--------------------|
 | A    | H(X, ph="", osth=th(B))              | No, B changed       |
 | B'   | H(X', ph=X'.parent_hash, osth=th(A)) | Yes                 |
 | C'   | H(Z', ph=Z'.parent_hash, osth=th(D)) | Yes                 |


### PR DESCRIPTION
Update all tables to use hyphens for table dividers instead of equal signs. Suggesting this because using equal signs leads to the tables not being rendered correctly on GitHub (preview below).

I tried to see if there's a reason for using one over the other, but couldn't find one. If there's some reason to use equal signs, or if this is considered a non-issue, feel free to close this.

---

##### Using equal signs

| this  | is    | an    | example |
|:======|:======|:======|:========|
| using | equal | signs | `=`     |

##### Using hyphens

| this  | is      | an      | example |
|:------|:--------|:--------|:--------|
| using | hyphens | instead | `-`     |