### PR TITLE
Update security and operational considerations

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -4878,7 +4878,7 @@ aspects of the DS design, such as:
 
 * How KeyPackages are distributed
 * How the ratchet tree is distributed
-* How proespective external joiners get a GroupInfo object for the group
+* How prospective external joiners get a GroupInfo object for the group
 * Whether MLSPlaintext or MLSCiphertext messages are used for Proposal and
   Commit messages
 
@@ -4925,11 +4925,11 @@ Welcome message, then they can identify the KeyPackage representing the new
 member.  If the party can also associate the Welcome with a group, then the
 party can infer that the identified new member was added to that group.
 
-Note that these information leaks reveal the group's membership to the degree
+Note that these information leaks reveal the group's membership only to the degree
 that that membership is revealed by the contents of a member's LeafNode in the
 ratchet tree.  In some cases, this may be quite direct, e.g., due to credentials
 attesting to identifiers such as email addresses.  An application could
-cosntruct a member's leaf node to be less identifying, e.g., by using a
+construct a member's leaf node to be less identifying, e.g., by using a
 pseudonymous credential and frequently rotating encryption and signature keys.
 
 ## Authentication

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -4863,7 +4863,7 @@ ratchet tree to new members is to send it in a Welcome message as a
 `ratchet_tree` extension.  If an application distributes the tree in some other
 way, its security will depend on that application mechanism.
 
-A party observing these fields might be able to infer certain metadata about the
+A party observing these fields might be able to infer certain properties of the
 group:
 
 * Group ID
@@ -4872,10 +4872,9 @@ group:
 * Group extensions
 * Group membership
 
-These fields are typically protected from parties other than the DS by applying
-"hop by hop" transport encryption (in contrast to the "end to end" protections
-provided by MLS). Whether the DS is exposed to unencrypted fields depends on
-several aspects of the DS design, such as:
+The amount of metadata exposed to parties outside the group, and thus the
+ability of these parties to infer the group's properties, depends on several
+aspects of the DS design, such as:
 
 * How KeyPackages are distributed
 * How the ratchet tree is distributed


### PR DESCRIPTION
Fixes #762
Fixes #763
Fixes #815
Fixes #813

* Add a paragraph to Operational Context describing additional security services that the DS can provide
* Add a citation to security analyses via the MLS Architecture
* Add a section discussing metadata protection