### PR TITLE
Validate additional properties of unmerged leaves

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -4419,9 +4419,14 @@ welcome_key = KDF.Expand(welcome_secret, "key", AEAD.Nk)
   * For each non-empty leaf node, validate the LeafNode as described in
     {{leaf-node-validation}}.
 
-  * For each non-empty parent node, verify that each entry in the node's
-    `unmerged_leaves` represents a non-blank leaf node that is a descendant of
-    the parent node.
+  * For each non-empty parent node and each entry in the node's
+    `unmerged_leaves` field:
+
+    * Verify that the entry represents a non-blank leaf node that is a
+      descendant of the parent node.
+
+    * Verify that every intermediate node beween the leaf node and the parent
+      node also has an entry for the leaf node in its `unmerged_leaves`.
 
 * Identify a leaf whose LeafNode is
   identical to the one in the KeyPackage.  If no such field exists, return an

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -4425,8 +4425,8 @@ welcome_key = KDF.Expand(welcome_secret, "key", AEAD.Nk)
     * Verify that the entry represents a non-blank leaf node that is a
       descendant of the parent node.
 
-    * Verify that every intermediate node beween the leaf node and the parent
-      node also has an entry for the leaf node in its `unmerged_leaves`.
+    * Verify that every non-blank intermediate node beween the leaf node and the
+      parent node also has an entry for the leaf node in its `unmerged_leaves`.
 
 * Identify a leaf whose LeafNode is
   identical to the one in the KeyPackage.  If no such field exists, return an


### PR DESCRIPTION
In discussion of #834, it came up that the current tree validation rules are loose enough that they allow configurations of `unmerged_leaves` that could not come about by normal operations.  This PR adds a check to enforce that if a node is unmerged at a parent node, it is also unmerged at every node between that parent node and the unmerged leaf.  

This is clearly a necessary property of any honestly-created tree, given the way `unmerged_leaves` entries are set and cleared (including the possible changes in #834).  I think it is also sufficient, but I don't have a proof on hand.