### PR TITLE
Remove "MLS" prefix on structs

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -5449,12 +5449,12 @@ Template:
 
 Initial contents:
 
-| Label           | Recommended | Reference |
-|:----------------|:------------|:----------|
-| "MLSContentTBS" | Y           | RFC XXXX  |
-| "LeafNodeTBS"   | Y           | RFC XXXX  |
-| "KeyPackageTBS" | Y           | RFC XXXX  |
-| "GroupInfoTBS"  | Y           | RFC XXXX  |
+| Label              | Recommended | Reference |
+|:-------------------|:------------|:----------|
+| "FramedContentTBS" | Y           | RFC XXXX  |
+| "LeafNodeTBS"      | Y           | RFC XXXX  |
+| "KeyPackageTBS"    | Y           | RFC XXXX  |
+| "GroupInfoTBS"     | Y           | RFC XXXX  |
 
 ## MLS Exporter Labels
 


### PR DESCRIPTION
Fixes #759 

As discussed in #759, this PR makes the following terminology changes:

| Before                      | After                     |
|:----------------------------|:--------------------------|
| MLSMessage                  | MLSMessage                |
| MLSContent                  | GroupContent              |
| MLSContentTBS               | GroupContentTBS           |
| MLSContentAuthData          | GroupContentAuthData      |
| MLSAuthenticatedContent     | AuthenticatedContent      |
| MLSContentTBM               | AuthenticatedContentTBM   |
| MLSSenderData               | SenderData                |
| MLSSenderDataAAD            | SenderDataAAD             |
| MLSCiphertextContent        | AuthenticatedContentTBE   |
| MLSCiphertextContentAAD     | ContentAAD                |
| MLSPlaintext                | PublicMessage             |
| MLSCiphertext               | PrivateMessage            |

It might be useful to review the two commits here separately.  The first is just a global search-and-replace.  The second is a light review for grammar ("a" vs. "an"), and makes a few small copy edits.