### PR TITLE
Add label and context to public-key encryption

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1389,11 +1389,11 @@ And its fields set to:
 
 ~~~
 label = "MLS 1.0 " + Label;
-content = Context;
+context = Context;
 ~~~
 
 Here, the functions `SealBase` and `OpenBase` are defined {{RFC9180}}, using the
-HPKE algorithms specified by the group's cipehersuite.  If MLS extensions
+HPKE algorithms specified by the group's ciphersuite.  If MLS extensions
 require HPKE encryption operations, they should re-use the EncryptWithLabel
 construction, using a distinct label.  To avoid collisions in these labels, an
 IANA registry is defined in {{mls-public-key-encryption-labels}}.
@@ -2493,8 +2493,8 @@ path_secret =
                    group_context, kem_output, ciphertext)
 ~~~
 
-Here `node_public_key` is the public key of the node that the path secret is
-being encrypted for, `group_context` is the provisional GroupContext object for
+Here `node_public_key` is the public key of the node for which the path secret is
+encrypted, `group_context` is the provisional GroupContext object for
 the group, and the `EncryptWithLabel` function is as defined in
 {{public-key-encryption}}.
 


### PR DESCRIPTION
As discussed in the virtual interim 2022-12-16, it is possible that extensions might be tempted to re-use HPKE public keys created for MLS.  Even within MLS, we have two different public-key encryption cases, Welcome and Commit (though these currently use different keys).

Currently, for Commit encryption, the HPKE `info` parameter is set to the group context.  The content of `info` is actually undefined for Welcome encryption (!)  This PR makes the following changes:

* Define general `EncryptWithLabel` and `DecryptWithLabel` functions that populte the HPKE `info` parameter with an encoded label and context
* Apply these to Commit and Welcome encryption:
    * Commit: label="UpdatePathNode", context=`group_context`
    * Welcome: label="Welcome", context=`encrypted_group_info`
* Add an IANA registry of public-key encryption labels (as for signing)

There is also a bit of reorganization of the Ciphersuites section to split it into three subsections.