### PR TITLE
A different check for the length code

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -702,8 +702,8 @@ ReadVarint(data):
   repeat length-1 times:
     v = (v << 8) + data.next_byte()
 
-  // Check that the encoder used the minimum bits required
-  if prefix >= 1 && v < (1 << (8*(1 << (prefix-1))-2)):
+  // Check if the value would fit in half the provided length.
+  if prefix >= 1 && v < (1 << (8*(length/2) - 2)):
     raise Exception('minimum encoding was not used')
 
   return v


### PR DESCRIPTION
Yes, this is not minimal (@sureshkrishnan suggested something closer to that), but I think that this is easier again to understand.

A smaller version checks against `1 << (4*len - 2)`, but that doesn't make much sense.