### PR TITLE
Clarify transcript hash initialization

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -3064,20 +3064,50 @@ Commit. Each Commit thus confirms the whole transcript of Commits up to that
 point, except for the latest Commit's confirmation tag.
 
 ~~~ aasvg
- epoch 0                               epoch 1                               epoch 2                               epoch 3
-    |                                     |                                     |                                     |
-    +-------------- commit1 --------------+-------------- commit2 --------------+-------------- commit3 --------------+ ...
-    |                 |                   |                 |                   |                 |                   |
-    +--- confirmed ---+--- confirm_tag ---+--- confirmed ---+--- confirm_tag ---+--- confirmed ---+--- confirm_tag ---+
-    |                 |                   |                 |                   |                 |                   |
-                      |          ^        |                 |          ^        |                 |          ^        |
-                      V          |        V                 V          |        V                 V          |        V
-interim[0] -----> confirmed[1] --+    interim[1] -----> confirmed[2] --+    interim[2] -----> confirmed[3] --+    interim[3]
-  = ""                           |                                     |                                     |
-                                 |                                     |                                     |
-                           confirm_key[1]                        confirm_key[2]                        confirm_key[3]
+                                                             ...
+
+                                                              |
+                                                              |
+                                                              V
+                                                     +-----------------+
+                                                     |  interim_[N-1]  |
+                                                     +--------+--------+
+                                                              |
+     .--------------.         +------------------+            |
+    |  Ratchet Tree  |        | wire_format      |            |
+    |  Key Schedule  |<-------+ content          |            |
+     '-------+------'         |   epoch = N-1    +------------+
+             |                |   commit         |            |
+             V                | signature        |            V
+ +------------------------+   +------------------+   +-----------------+
+ |  confirmation_key_[N]  +-->| confirmation_tag |<--+  confirmed_[N]  |
+ +------------------------+   +--------+---------+   +--------+--------+
+                                       |                      |
+                                       |                      V
+                                       |             +-----------------+
+                                       +------------>|   interim_[N]   |
+                                                     +--------+--------+
+                                                              |
+     .--------------.         +------------------+            |
+    |  Ratchet Tree  |        | wire_format      |            |
+    |  Key Schedule  |<-------+ content          |            |
+     '-------+------'         |   epoch = N      +------------+
+             |                |   commit         |            |
+             V                | signature        |            V
+ +------------------------+   +------------------+   +-----------------+
+ | confirmation_key_[N+1] +-->| confirmation_tag |<--+ confirmed_[N+1] |
+ +------------------------+   +--------+---------+   +--------+--------+
+                                       |                      |
+                                       |                      V
+                                       |             +-----------------+
+                                       +------------>|  interim_[N+1]  |
+                                                     +--------+--------+
+                                                              |
+                                                              V
+
+                                                             ...
 ~~~
-{: title="Evolution of the transcript hashes"}
+{: title="Evolution of the transcript hashes through two epoch changes"}
 
 ## External Initialization
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -3028,6 +3028,7 @@ interim[0] -----> confirmed[1] --+    interim[1] -----> confirmed[2] --+    inte
                                  |                                     |                                     |
                            confirm_key[1]                        confirm_key[2]                        confirm_key[3]
 ~~~
+{: title="Evolution of the transcript hashes"}
 
 ## External Initialization
 


### PR DESCRIPTION
The current text on initializing the transcript hash is ambiguous.  In particular, it never tells you how to compute the first `interim_transcript_hash`. This PR provides clearer initialization instructions, and a figure that summarizes the transcript hash evolution [2].

<img width="596" alt="image" src="https://user-images.githubusercontent.com/75597/217567652-17e86387-dcdf-476d-ba8d-8a9192e285fd.png">

[1] To be clear, I think the intent is clear and all current implementations are consistent.  The text is just bad.
[2] The diagram is a little over-the-top elaborate.  I would be OK removing it :)