### PR TITLE
Change MLS-Exporter label from "exporter" to "exported"

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -3214,7 +3214,7 @@ be used by an application to derive new secrets for use outside of MLS.
 ~~~ pseudocode
 MLS-Exporter(Label, Context, Length) =
        ExpandWithLabel(DeriveSecret(exporter_secret, Label),
-                         "exporter", Hash(Context), Length)
+                         "exported", Hash(Context), Length)
 ~~~
 
 Applications SHOULD provide a unique label to `MLS-Exporter` that


### PR DESCRIPTION
Currently the "exporter" label is used two times : to derive `exporter_secret`, and in `MLS-Exporter`.
I'm not sure it's really problematic, but using different labels doesn't cost much, hence this PR.