### PR TITLE
Make the ratchet tree non-malleable

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -4688,12 +4688,12 @@ trees outlined in {{array-based-trees}}.)
 
 If the tree has `2^d` leaves, then it has `2^(d+1) - 1` nodes.  The
 `ratchet_tree` vector logically has this number of entries, but the sender
-SHOULD NOT include blank nodes after the last non-blank node.  If a receiver
-encounters a vector whose length `L` is not of the form `2^(d+1) - 1`, then the
-receiver MUST extend it to the right with blank values until it has such a
-length, adding the minimum number of blank values possible.  (Obviously, this
-may be done "virtually", by synthesizing blank nodes when required, as opposed
-to actually changing the structure in memory.)
+MUST NOT include blank nodes after the last non-blank node.  The receiver MUST
+check that the last node in `ratchet_tree` is non-blank, and extend it to the
+right until it has a length of the form `2^(d+1) - 1`, adding the minimum number
+of blank values possible.  (Obviously, this may be done "virtually", by
+synthesizing blank nodes when required, as opposed to actually changing the
+structure in memory.)
 
 The leaves of the tree are stored in even-numbered entries in the array (the
 leaf with index `L` in array position `2*L`). The root node of the tree is at


### PR DESCRIPTION
As discussed in mlswg/mls-implementations#102 .

Currently, there are several valid `ratchet_tree` for one tree: the sender can choose ("SHOULD") to omit some (but not all) blank nodes at the right of the tree.
This PR changes this: the sender MUST omit all the blank nodes at the right of the tree, and the receiver MUST check that it was done correctly (i.e., the last node of `ratchet_tree` is non-blank).