### PR TITLE
Comments from Nick Sullivan

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -190,13 +190,13 @@ services are provided:
   * Sequencing of Commit messages (see {{sequencing}})
 
 The DS and AS may also apply additional policies to MLS operations to obtain
-additional security properties, especially in cases where MLS handshake messages
+stronger security properties, especially in cases where MLS handshake messages
 are transmitted unencrypted (as PublicMessage objects).  For example, MLS
 enables any participant to add or remove members of a group; a DS could enforce
 a policy that only certain members are allowed to perform these operations.  MLS
 authenticates all members of a group; a DS could help ensure that only clients
 with certain types of credential are admitted. MLS provides no inherent
-protection against denial of service; A DS could also enforce rate limits in
+protection against denial of service; a DS could also enforce rate limits in
 order to mitigate these risks.
 
 ##  Change Log
@@ -587,7 +587,7 @@ Key Package:
 
 Group Context:
 : An object that summarizes the shared, public state of the group. The group
-  context is typically distributed in a signed GroupInfo message, which provided
+  context is typically distributed in a signed GroupInfo message, which is provided
   to new members to help them join a group.
 
 Signature Key:
@@ -1045,7 +1045,7 @@ well as a public key that can be used to encrypt a secret to the existing
 members of the group.  When the new member Z wishes to join, they download the
 GroupInfo object and use it to form a Commit of a special form that adds Z to
 the group (as detailed in {{joining-via-external-commits}}).  The existing
-members of the group process this external Commit in a similar way to normal
+members of the group process this external Commit in a similar way to a normal
 Commit, advancing to a new epoch in which Z is now a member of the group.
 
 ~~~
@@ -1065,7 +1065,7 @@ A              B              Z          Directory        Channel
 |              |              |<----------------------------+
 |              |              |              |              |
 ~~~
-{: #groupinfo-flow title"Client A publishes a GroupInfo object and Client Z uses
+{: #groupinfo-flow title="Client A publishes a GroupInfo object and Client Z uses
 it to join the group"}
 
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1242,8 +1242,8 @@ of private keys corresponding to the public keys in nodes in the tree.  The
 private key corresponding to a parent node is known only to members at leaf
 nodes that are descedants of that node.  The private key corresponding to a leaf
 node is known only to the member at that leaf node.  A leaf node is _unmerged_
-relative to one of its ancestor node if the member at the leaf node does not
-know the private key corresponding the ancestor node.
+relative to one of its ancestor nodes if the member at the leaf node does not
+know the private key corresponding to the ancestor node.
 
 Every node, regardless of whether the node is blank or populated, has
 a corresponding _hash_ that summarizes the contents of the subtree

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2371,12 +2371,9 @@ The client verifies the validity of a LeafNode using the following steps:
   * If the LeafNode appears in the `leaf_node` value of the UpdatePath in
     a Commit, verify that `leaf_node_source` is set to `commit`.
 
-* Verify that the leaf node's `signature_key` value does not appear in any other
-  leaf node in the group's ratchet tree.
-
-* Verify that the leaf node's `encryption_key` value does not appear in any
-  other node of the group's ratchet tree (including both leaf nodes and parent
-  nodes).
+* Verify that the following fields are unique among the members of the group:
+    * `signature_key`
+    * `encryption_key`
 
 ## Ratchet Tree Evolution
 
@@ -5471,12 +5468,11 @@ to a new group is more likely to be fresh and less likely to be compromised.
 
 ## Uniqueness of Ratchet Tree Key Pairs
 
-The encryption and signature keys stored in ratchet tree nodes MUST be distinct
-from one another.  If two members' leaf nodes have the same signature key, then
-the data origin authentication properties afforded by signatures within the
-group are degraded.  If two nodes have the same encryption key, it creates a
-"double join" scenario where a removed member may still be able to compute the
-group's secrets.
+The encryption and signature keys stored in the `encryption_key` and
+`signature_key` fields of ratchet tree nodes MUST be distinct from one another.
+If two members' leaf nodes have the same signature key, for example, then the
+data origin authentication properties afforded by signatures within the group
+are degraded.
 
 Uniqueness of keys in leaf nodes is assured by explicit checks on leaf nodes
 being added to the tree by Add or Update proposals, or in the `path` field of a
@@ -5484,7 +5480,6 @@ Commit.  Details can be found in {{leaf-node-validation}},
 {{proposal-list-validation}}, and {{processing-a-commit}}.  Uniqueness of
 encryption keys in parent nodes is assured by checking that the keys in an
 UpdatePath are not found elsewhere in the tree (see {{processing-a-commit}}.
-
 
 ## KeyPackage Reuse
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -1043,8 +1043,9 @@ message flows in other ways.  For example:
   broadly, say if the application only had access to a broadcast channel for the
   group.
 
-* Proposal messages don't necessarily need to be sent to all group members. They
-  only need to reach a member who will commit them.
+* Proposal messages don't need to be immediately sent to all group members.  They need to
+  be available to the committer before generating a commit, and to other members before
+  processing the commit.
 
 * The sender of a Commit doesn't necessarily have to wait to receive its own
   Commit back before advancing its state. It only needs to know that its Commit


### PR DESCRIPTION
Nick sent me some late comments, which I have reflected in this PR.  The most significant changes are:

* A new section in the overview covering external commits, so that that concept has been introduced before it is encountered further down.

* A new subsection in the security considerations elaborating why key uniqueness mattes, and some slightly stronger requirements around it in the appropriate spots. 