### PR TITLE
Resolve ambiguities found in interop testing

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -4013,8 +4013,13 @@ struct {
 
 A PreSharedKey proposal is invalid if any of the following is true:
 
-* The `psktype` in the PreSharedKeyID struct is set to `resumption` and
-  the `usage` is `reinit` or `branch`.
+* The PreSharedKey proposal is not being processed as part of a reinitialization
+  of the group (see {{reinitialization}}), and the PreSharedKeyID has `psktype`
+  set to `resumption` and `usage` set to `reinit`.
+
+* The PreSharedKey proposal is not being processed as part of a subgroup
+  branching operation (see {{subgroup-branching}}), and the PreSharedKeyID has
+  `psktype` set to `resumption` and `usage` set to `branch`.
 
 * The `psk_nonce` is not of length `KDF.Nh`.
 

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -3914,9 +3914,6 @@ struct {
 } Proposal;
 ~~~
 
-A Proposal object whose `proposal_type` is one of the GREASE values defined in
-{{grease}} MUST be rejected as malformed.
-
 On receiving a FramedContent containing a Proposal, a client MUST verify the
 signature inside FramedContentAuthData and that the `epoch` field of the enclosing
 FramedContent is equal to the `epoch` field of the current GroupContext object.
@@ -5162,6 +5159,15 @@ selection of values chosen from these GREASE values:
 * `KeyPackage.extensions`
 * `GroupInfo.extensions`
 
+GREASE values MUST NOT be included in the `proposal_type` field of a Proposal
+object or the `credential_type` field of a Credential object.  A Proposal or
+Credential containing a GREASE value in one of these fields MUST be rejected as
+malformed.  Extensions with GREASE types MUST NOT be included in GroupContext
+extensions, and thus MUST NOT appear in `GroupContext.extensions` or
+GroupContextExtensions proposals.  A GroupContext object or
+GroupContextExtensions proposal containing GREASE a extension MUST be rejected as
+malformed.
+
 For the KeyPackage and GroupInfo extensions, the `extension_data` for GREASE
 extensions MAY have any contents selected by the sender, since they will be
 ignored by a correctly-implemented receiver.  For example, a sender might
@@ -5177,6 +5183,7 @@ appear in the fields listed above, and not, for example, in the `proposal_type`
 field of a Proposal.  Clients MUST NOT implement any special processing rules
 for how to handle these values when receiving them, since this negates their
 utility for detecting extensibility failures.
+
 GREASE values MUST be handled using normal logic for processing unsupported
 values.  When comparing lists of capabilities to identify mutually-supported
 capabilities, clients MUST represent their own capabilities with a list

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -5159,19 +5159,19 @@ selection of values chosen from these GREASE values:
 * `KeyPackage.extensions`
 * `GroupInfo.extensions`
 
-GREASE values MUST NOT be included in the `proposal_type` field of a Proposal
-object or the `credential_type` field of a Credential object.  A Proposal or
-Credential containing a GREASE value in one of these fields MUST be rejected as
-malformed.  Extensions with GREASE types MUST NOT be included in GroupContext
-extensions, and thus MUST NOT appear in `GroupContext.extensions` or
-GroupContextExtensions proposals.  A GroupContext object or
-GroupContextExtensions proposal containing GREASE a extension MUST be rejected as
-malformed.
-
 For the KeyPackage and GroupInfo extensions, the `extension_data` for GREASE
 extensions MAY have any contents selected by the sender, since they will be
 ignored by a correctly-implemented receiver.  For example, a sender might
 populate these extensions with a randomly-sized amount of random data.
+
+GREASE values MUST NOT be sent in the following fields, because an unsupported
+value in one these fields (including a GREASE value), will cause the enclosing
+message to be rejected:
+
+* `Proposal.proposal_type`
+* `Credential.credential_type`
+* `GroupContext.extensions`
+* `GroupContextExtensions.extensions`
 
 A set of values reserved for GREASE have been registered in the various
 registries in {{iana-considerations}}.  This prevents conflict between GREASE


### PR DESCRIPTION
@mulmarta and I have completed interop testing that covers all of the functionality in the spec.  We found a couple of places where there were ambiguities in the spec that led to different implementation decisions, and in the process of resolving those, found a couple of errors / omissions in drarft-19.

* The current PSK proposal validation forbids `resumption` with `usage` other than `applications`.  The branch and reinit sections call for the creation of PSK proposals with types `branch` and `reinit`.  Given the text in the PSK section, these proposals would be invalid.  This PR explicitly allows `branch` and `reinit` in the specific context of those operations.  (This is a little pro-forma, since the PSK proposals are only seen by the committer.  But it seems good to allow the committer to have consistent PSK proposal validation logic.)

* The text says that Add, Remove, and ReInit proposals can be sent by external senders, but is silent about other proposal types.  This PR explicitly indicates which proposal types may be originated by external senders, and adds an IANA registry column to track.

* GREASE values for proposal types, credential types, and extension types are defined for use in Capabilities, but nothing currently forbids their use elsewhere.  This PR forbids their use in actual Proposal or Credential objects, and in GroupContext extensions.

* The `msg_type` field of the Proposal object was inconsistently referred to as both `msg_type` and `proposal_type`.  This PR changes it to be `proposal_type` everywhere.