### PR TITLE
One more minor clarification for AUTH48

### DIFF
--- a/auth48/rfc9420.authors.xml
+++ b/auth48/rfc9420.authors.xml
@@ -550,7 +550,7 @@ A                B                C            Directory       Channel
         <t><xref target="create-flow"/> shows how these pre-published KeyPackages are used to create a group.
 When client A wants to establish a group with clients B and C, it first initializes a
 group state containing only itself and downloads KeyPackages for B and C. For
-each member, A generates an Add message and a Commit message to add that member and then
+each member, A generates an Add proposal and a Commit message to add that member and then
 broadcasts the two messages to the group. Client A also generates a Welcome message and sends it
 directly to the new member (there's no need to send it to the group). Only after
 A has received its Commit message back from the Delivery Service does it update its

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -541,7 +541,7 @@ A                B                C            Directory       Channel
 {{create-flow}} shows how these pre-published KeyPackages are used to create a group.
 When client A wants to establish a group with clients B and C, it first initializes a
 group state containing only itself and downloads KeyPackages for B and C. For
-each member, A generates an Add message and a Commit message to add that member and then
+each member, A generates an Add proposal and a Commit message to add that member and then
 broadcasts the two messages to the group. Client A also generates a Welcome message and sends it
 directly to the new member (there's no need to send it to the group). Only after
 A has received its Commit message back from the Delivery Service does it update its


### PR DESCRIPTION
In #879, @rohan-wire [proposed a clarification in the protocol overview](https://github.com/mlswg/mls-protocol/pull/879#discussion_r1232195438) that the Add and Commit messages don't have to be separate messages.  He and I talked offline, and came to a compromise: On the one hand, you always send an Add and a Commit (even if the Add is inlined), but on the other hand, the Add may just be a proposal, not a message.  So this PR just changes "Add message" to "Add proposal".