### PR TITLE
Round 2 of AUTH48 edits

### DIFF
--- a/auth48/QUESTIONS.md
+++ b/auth48/QUESTIONS.md
@@ -33,7 +33,7 @@
 
 * The document is inconsistent as to whether a <t> is used inside <dd>.
 
-## Questions and Answers
+## Questions and Answers (Round 1)
 
 > 1) <!-- [rfced] xml2rfc returns a number of warnings and suggest that
 > viewBox be used.  Please review and let us know if you would like to make
@@ -813,3 +813,73 @@ I concur with these changes.
 This was discussed during IESG review:
 
 https://mailarchive.ietf.org/arch/msg/mls/jSMQHXxcY3bX8S-xefyjbX4KFzE/
+
+## Questions and Answers (Round 2)
+
+> 1) We read the comments in the GitHub PR that were included above the
+> Questions/Answers. Overall, we are okay with the changes made. Note that we
+> did not look further into whether or not <t> is used inside <dd>.  Please let
+> us know if there are specific instances that need review.
+> 
+> > * The document is inconsistent as to whether a <t> is used inside <dd>
+
+I reviewed, and did not find any instances of <t> inside of <dd>.  I may have
+been mistaken in this comment.
+
+
+> 2) Thank you for providing the keywords.  Note that they are formatted as follows in XML file:
+> 
+>    <keyword>security</keyword>
+>    <keyword>authenticated key exchange</keyword>
+>    <keyword>end-to-end encryption</keyword>
+
+Thanks, that looks correct to me.  I have adjusted the Markdown so that the
+generated XML matches this format.
+
+
+> 3) In Section 3.2, we removed the period from the title of Figure 4 (sentence form is okay but with no period).
+> 
+> 4) In Section 12.1.8, we reverted the hyphen in “newly-hired” as we do not hyphenate adverbs that end in “ly”.
+> 
+> 5) In Sections 12.1.8 and 12.4, we added quote marks to the IANA registry name - 2 instances.
+> 
+> Old:
+>    MLS Proposal Types registry
+> 
+> Current:
+>    "MLS Proposal Types” registry
+
+These changes are good with me.
+
+
+> 6) In Section 12.4.2, the text does not parse with the removal of “is”. Please let us know how you would like to update (perhaps remove “that”).
+> 
+> Current:
+>   *  Verify that the signature on the FramedContent message as
+>       described in Section 6.1.
+
+Sorry, I should have removed the "that", so that it reads "Verify the signature..."
+
+
+> 7) In Section 15.1, we reverted the change to the citation spacing. Our practice is to separate citations with one space.
+> 
+> Old:
+>   Application messages MAY be padded to provide some resistance against
+>   traffic analysis techniques over encrypted traffic [CLINIC][HCJ16].
+> 
+> New:
+>   Application messages MAY be padded to provide some resistance against
+>   traffic analysis techniques over encrypted traffic
+>   [CLINIC] [HCJ16].
+
+This is fine.  I think the spacing is an artifact of the XML generation.
+
+
+> 8) As requested, we checked that all instances of “ciphersuite” were updated to “cipher suite” - no additional changes.
+
+Thanks!
+
+
+> 9) FYI - The AD will need to approve some changes that are beyond editorial, and IANA will need to make some changes to their registries. We will request these actions once all author changes are complete.
+
+Duly noted.

--- a/auth48/rfc9420.authors.xml
+++ b/auth48/rfc9420.authors.xml
@@ -42,7 +42,9 @@
     <date month="May" year="2023"/>
     <area>sec</area>
     <workgroup>mls</workgroup>
-    <keyword>security, authenticated key exchange, end-to-end encryption</keyword>
+    <keyword>security</keyword>
+    <keyword>authenticated key exchange</keyword>
+    <keyword>end-to-end encryption</keyword>
     <abstract>
       <t>Messaging applications are increasingly making use of end-to-end
 security mechanisms to ensure that messages are only accessible to
@@ -688,7 +690,7 @@ network.  Applications should take care that they do not send MLS messages at a
 rate that will cause problems such as network congestion, especially if they are
 not following the above recommendation (e.g., sending MLS directly over UDP instead).</t>
         <figure anchor="update-flow">
-          <name>Client B proposes to update its key, and client A commits the proposal.</name>
+          <name>Client B proposes to update its key, and client A commits the proposal</name>
           <artset>
             <artwork type="svg">
               <svg xmlns="http://www.w3.org/2000/svg" class="diagram" font-family="monospace" font-size="13px" height="304" text-anchor="middle" version="1.1" viewBox="0 0 528 304" width="528">
@@ -4517,7 +4519,7 @@ that is outside the group in two cases. One case, indicated by the <tt>external<
 allows an entity outside the group to submit proposals to the group.
 For example, an automated service might propose
 removing a member of a group who has been inactive for a long time, or propose adding
-a newly-hired staff member to a group representing a real-world team.
+a newly hired staff member to a group representing a real-world team.
 An <tt>external</tt> sender might send a ReInit proposal to enforce a changed policy
 regarding MLS versions or cipher suites.</t>
           <t>The <tt>external</tt> SenderType requires that signers are pre-provisioned
@@ -4552,7 +4554,7 @@ an <tt>external</tt> sender:</t>
           <t>Messages from <tt>external</tt> senders containing proposal types other than the above
 <bcp14>MUST</bcp14> be rejected as malformed.  New proposal types defined in the future <bcp14>MUST</bcp14>
 define whether they may be sent by <tt>external</tt> senders.  The "Ext" column in
-the MLS Proposal Types registry (<xref target="mls-proposal-types"/>) reflects this property.</t>
+the "MLS Proposal Types" registry (<xref target="mls-proposal-types"/>) reflects this property.</t>
           <section anchor="external-senders-extension">
             <name>External Senders Extension</name>
             <t>The <tt>external_senders</tt> extension is a group context extension that contains
@@ -4723,7 +4725,7 @@ The only proposal types defined in this document that do not require a path are:
         <t>New proposal types <bcp14>MUST</bcp14> state whether they require a path. If any instance of a
 proposal type requires a path, then the proposal type requires a path. This
 attribute of a proposal type is reflected in the "Path Required" field of the
-MLS Proposal Types registry defined in <xref target="mls-proposal-types"/>.</t>
+"MLS Proposal Types" registry defined in <xref target="mls-proposal-types"/>.</t>
         <t>Update and Remove proposals are the clearest examples of proposals that require
 a path.  An UpdatePath is required to evict the removed member or the old
 appearance of the updated member.</t>
@@ -5707,7 +5709,7 @@ order to produce the required nonce and key for encryption or decryption.</t>
         <name>Padding</name>
         <t>Application messages <bcp14>MAY</bcp14> be padded to provide some resistance
 against traffic analysis techniques over encrypted traffic
-<xref target="CLINIC"/><xref target="HCJ16"/>.
+<xref target="CLINIC"/> <xref target="HCJ16"/>.
 While MLS might deliver the same payload less frequently across
 a lot of ciphertexts than traditional web servers, it might still provide
 the attacker enough information to mount an attack. If Alice asks Bob
@@ -7185,7 +7187,7 @@ collisions.</t>
         <t>Template:</t>
         <ul spacing="normal">
           <li>Label: The string to be used as the <tt>Label</tt> parameter to <tt>MLS-Exporter</tt></li>
-          <li>Recommended: Same as in <xref target="mls-ciphers-uites"/></li>
+          <li>Recommended: Same as in <xref target="mls-cipher-suites"/></li>
           <li>Reference: The document where this label is defined</li>
         </ul>
         <t>The registry has no initial contents, since it is intended to be used by

--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -6,7 +6,10 @@ category: std
 
 ipr: trust200902
 area: sec
-keyword: security, authenticated key exchange, end-to-end encryption
+keyword:
+  - security
+  - authenticated key exchange
+  - end-to-end encryption
 workgroup: mls
 
 stand_alone: yes
@@ -641,7 +644,7 @@ A              B     ...      Z          Directory        Channel
 |              |              |              |              |
 ~~~
 {: #update-flow title="Client B proposes to update its key, and client A commits the
-proposal."}
+proposal"}
 
 Members are removed from the group in a similar way, as shown in {{remove-flow}}.
 Any member of the group can send a Remove proposal followed by a
@@ -3724,7 +3727,7 @@ that is outside the group in two cases. One case, indicated by the `external` Se
 allows an entity outside the group to submit proposals to the group.
 For example, an automated service might propose
 removing a member of a group who has been inactive for a long time, or propose adding
-a newly-hired staff member to a group representing a real-world team.
+a newly hired staff member to a group representing a real-world team.
 An `external` sender might send a ReInit proposal to enforce a changed policy
 regarding MLS versions or cipher suites.
 
@@ -3753,7 +3756,7 @@ an `external` sender:
 Messages from `external` senders containing proposal types other than the above
 MUST be rejected as malformed.  New proposal types defined in the future MUST
 define whether they may be sent by `external` senders.  The "Ext" column in
-the MLS Proposal Types registry ({{mls-proposal-types}}) reflects this property.
+the "MLS Proposal Types" registry ({{mls-proposal-types}}) reflects this property.
 
 #### External Senders Extension
 
@@ -3948,7 +3951,7 @@ The only proposal types defined in this document that do not require a path are:
 New proposal types MUST state whether they require a path. If any instance of a
 proposal type requires a path, then the proposal type requires a path. This
 attribute of a proposal type is reflected in the "Path Required" field of the
-MLS Proposal Types registry defined in {{mls-proposal-types}}.
+"MLS Proposal Types" registry defined in {{mls-proposal-types}}.
 
 Update and Remove proposals are the clearest examples of proposals that require
 a path.  An UpdatePath is required to evict the removed member or the old
@@ -4125,7 +4128,7 @@ A member of the group applies a Commit message by taking the following steps:
     `sender_data_secret` and the (key, nonce) pair from the step on the sender's
     hash ratchet indicated by the `generation` field.
 
-* Verify that the signature on the FramedContent message as described in
+* Verify the signature on the FramedContent message as described in
   {{content-authentication}}.
 
 * Verify that the `proposals` vector is valid according to the rules in


### PR DESCRIPTION
The RFC Editor replied to our edits (#879 #880) with a few more questions, comments, and edits.  This PR incorporates those comments into the Markdown and the author's XML, and fixes one thing where author input was required.  The new questions/comments are added to the bottom of QUESTIONS.md.